### PR TITLE
 feat: 방 입장 기능 구현

### DIFF
--- a/gotcha-socket/build.gradle
+++ b/gotcha-socket/build.gradle
@@ -3,6 +3,8 @@ dependencies {
     implementation project(":gotcha-common")
     implementation project(":gotcha-domain")
     implementation project(":gotcha-auth")
+    implementation project(":gotcha-user")
+
 
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/gotcha-socket/src/main/java/socket_server/common/config/RedisIntegrationConfig.java
+++ b/gotcha-socket/src/main/java/socket_server/common/config/RedisIntegrationConfig.java
@@ -106,6 +106,8 @@ public class RedisIntegrationConfig {
                 ROOM_CREATE_INFO,                    // /sub/room/create/info
                 ROOM_LEAVE + "*",                    // /sub/room/leave/*
                 ROOM_UPDATE + "*",                   // /sub/room/update/*
+                ROOM_JOIN + "*",                     // /sub/room/join/*
+
 
                 // 게임
                 GAME_READY_CHANNEL + "*",            // /sub/game/ready/*

--- a/gotcha-socket/src/main/java/socket_server/common/config/RedisMessage.java
+++ b/gotcha-socket/src/main/java/socket_server/common/config/RedisMessage.java
@@ -6,5 +6,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public record RedisMessage(
         String userId,
         String topic,
-        Object payload)
+        String payload)
 {}

--- a/gotcha-socket/src/main/java/socket_server/common/constants/WebSocketConstants.java
+++ b/gotcha-socket/src/main/java/socket_server/common/constants/WebSocketConstants.java
@@ -10,6 +10,7 @@ public interface WebSocketConstants {
     //대기방 관련 채널
     String ROOM_PREFIX = "/sub/room/";
     String ROOM_LIST_INFO = ROOM_PREFIX + "list/info";
+    String ROOM_JOIN = ROOM_PREFIX+"join/"; // + roomId
     String ROOM_LEAVE = ROOM_PREFIX+"leave/"; // + roomId
     String ROOM_CREATE_INFO = ROOM_PREFIX + "create/info";
     String ROOM_UPDATE = ROOM_PREFIX + "update/"; // + roomId
@@ -19,7 +20,7 @@ public interface WebSocketConstants {
     String GAME_READY_CHANNEL = GAME_PREFIX + "ready/"; // + roomId
     String GAME_END_CHANNEL = GAME_PREFIX + "end/"; // + roomId
     String GAME_INFO_CHANNEL = GAME_PREFIX + "info/"; // + roomId
-    String GAME_START_CHANNEL = GAME_PREFIX + "start/"; // + roomId
+    String GAME_START_CHANNEL = GAME_PREFIX     + "start/"; // + roomId
 
     // 개인 유저 관련 채널
     String PERSONAL_PREFIX = "/sub/personal/";

--- a/gotcha-socket/src/main/java/socket_server/common/listener/PubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/common/listener/PubSubHandler.java
@@ -51,33 +51,5 @@ public abstract class PubSubHandler {
         }
     }
 
-    protected <T> T convertMessageToDto(Object raw, Class<T> clazz) {
-        try {
-            if (raw instanceof Map map) {
-                map.remove("@class"); //dto내에 또 dto가 들어있는 경우 발생하는 에러 방지용 코드.
-            }
-            return objectMapper.convertValue(raw, clazz);
-        } catch (Exception e) {
-            throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
-        }
-    }
-
-    protected <T> List<T> convertMessageToList(Object raw, Class<T> clazz) {
-        try {
-            if (raw instanceof String rawStr) { // String 으로 들어온 경우 readValue
-                return objectMapper.readValue(
-                        rawStr,
-                        objectMapper.getTypeFactory().constructCollectionType(List.class, clazz)
-                );
-            }
-
-            return objectMapper.convertValue( // else convertValue
-                    raw,
-                    objectMapper.getTypeFactory().constructCollectionType(List.class, clazz)
-            );
-        } catch (Exception e) {
-            throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
-        }
-    }
 
 }

--- a/gotcha-socket/src/main/java/socket_server/common/listener/PubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/common/listener/PubSubHandler.java
@@ -8,6 +8,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import socket_server.common.config.RedisMessage;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -44,7 +45,7 @@ public abstract class PubSubHandler {
     }
 
     // RedisIntegrationConfig에서 전달된 메시지가 RedisMessage 형식인지 검증
-    private void validatePayloadFormat(Object  payload){
+    private void validatePayloadFormat(Object payload){
         if (!(payload instanceof RedisMessage)) {
             throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
         }
@@ -60,4 +61,23 @@ public abstract class PubSubHandler {
             throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
         }
     }
+
+    protected <T> List<T> convertMessageToList(Object raw, Class<T> clazz) {
+        try {
+            if (raw instanceof String rawStr) { // String 으로 들어온 경우 readValue
+                return objectMapper.readValue(
+                        rawStr,
+                        objectMapper.getTypeFactory().constructCollectionType(List.class, clazz)
+                );
+            }
+
+            return objectMapper.convertValue( // else convertValue
+                    raw,
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, clazz)
+            );
+        } catch (Exception e) {
+            throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
+        }
+    }
+
 }

--- a/gotcha-socket/src/main/java/socket_server/common/listener/PubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/common/listener/PubSubHandler.java
@@ -6,6 +6,7 @@ import gotcha_common.exception.exceptionCode.GlobalExceptionCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import socket_server.common.config.RedisMessage;
+import socket_server.common.util.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.List;
@@ -16,12 +17,15 @@ import java.util.function.BiConsumer;
 @Slf4j
 public abstract class PubSubHandler {
 
-    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환기
     protected final SimpMessagingTemplate messagingTemplate;
     protected final Map<String, BiConsumer<String,  Object >> handlers;
+    protected final JsonSerializer jsonSerializer;
 
-    public PubSubHandler(SimpMessagingTemplate messagingTemplate) {
+
+
+    public PubSubHandler(SimpMessagingTemplate messagingTemplate, JsonSerializer jsonSerializer) {
         this.messagingTemplate = messagingTemplate;
+        this.jsonSerializer = jsonSerializer;
         this.handlers = new HashMap<>();
         initHandlers();
     }
@@ -50,6 +54,8 @@ public abstract class PubSubHandler {
             throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
         }
     }
+
+
 
 
 }

--- a/gotcha-socket/src/main/java/socket_server/common/util/JsonSerializer.java
+++ b/gotcha-socket/src/main/java/socket_server/common/util/JsonSerializer.java
@@ -1,0 +1,48 @@
+package socket_server.common.util;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gotcha_common.exception.CustomException;
+import gotcha_common.exception.exceptionCode.GlobalExceptionCode;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class JsonSerializer {
+    private final ObjectMapper objectMapper;
+
+    public JsonSerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    // Object to String(JSON)
+    public <T> String serialize(T object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
+        }
+    }
+
+    // String(JSON) to Object
+    public <T> T deserialize(String json, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(json, clazz);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
+        }
+    }
+
+    // String(JSON) to List
+    public <T> List<T> deserializeList(String json, Class<T> elementClass) {
+        try {
+            JavaType type = objectMapper.getTypeFactory().constructCollectionType(List.class, elementClass);
+            return objectMapper.readValue(json, type);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
+        }
+    }
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/handler/ChattingPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/handler/ChattingPubSubHandler.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import socket_server.common.listener.PubSubHandler;
+import socket_server.common.util.JsonSerializer;
 
 import static socket_server.common.constants.WebSocketConstants.*;
 
@@ -11,8 +12,8 @@ import static socket_server.common.constants.WebSocketConstants.*;
 @Qualifier("chattingPubSubHandler")
 public class ChattingPubSubHandler extends PubSubHandler {
 
-    public ChattingPubSubHandler(SimpMessagingTemplate messagingTemplate) {
-        super(messagingTemplate);
+    public ChattingPubSubHandler(SimpMessagingTemplate messagingTemplate, JsonSerializer jsonSerializer) {
+        super(messagingTemplate, jsonSerializer);
     }
 
     @Override

--- a/gotcha-socket/src/main/java/socket_server/domain/game/handler/GamePubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/handler/GamePubSubHandler.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import socket_server.common.listener.PubSubHandler;
+import socket_server.common.util.JsonSerializer;
 import socket_server.domain.game.dto.GameReadyStatus;
 
 import static socket_server.common.constants.WebSocketConstants.*;
@@ -12,8 +13,8 @@ import static socket_server.common.constants.WebSocketConstants.*;
 @Qualifier("gamePubSubHandler")
 public class GamePubSubHandler extends PubSubHandler {
 
-    public GamePubSubHandler(SimpMessagingTemplate messagingTemplate) {
-        super(messagingTemplate);
+    public GamePubSubHandler(SimpMessagingTemplate messagingTemplate, JsonSerializer jsonSerializer) {
+        super(messagingTemplate, jsonSerializer);
     }
 
     @Override
@@ -25,7 +26,7 @@ public class GamePubSubHandler extends PubSubHandler {
     }
 
     private void handleGameReady(String channel, Object object) {
-        GameReadyStatus gameReadyStatus = convertMessageToDto(object, GameReadyStatus.class);
+        GameReadyStatus gameReadyStatus = jsonSerializer.deserialize((String)object, GameReadyStatus.class);
         messagingTemplate.convertAndSend(channel, gameReadyStatus);
     }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/personal/handler/PersonalPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/personal/handler/PersonalPubSubHandler.java
@@ -6,6 +6,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import socket_server.common.config.RedisMessage;
 import socket_server.common.listener.PubSubHandler;
+import socket_server.common.util.JsonSerializer;
 import socket_server.domain.room.model.RoomMetadata;
 
 import static socket_server.common.constants.WebSocketConstants.PERSONAL_ROOM_CREATE_RESPONSE;
@@ -15,8 +16,8 @@ import static socket_server.common.constants.WebSocketConstants.PERSONAL_ROOM_CR
 @Qualifier("PersonalPubSubHandler")
 public class PersonalPubSubHandler extends PubSubHandler {
 
-    public PersonalPubSubHandler(SimpMessagingTemplate messagingTemplate) {
-        super(messagingTemplate);
+    public PersonalPubSubHandler(SimpMessagingTemplate messagingTemplate, JsonSerializer jsonSerializer) {
+        super(messagingTemplate, jsonSerializer);
     }
 
     @Override
@@ -26,7 +27,7 @@ public class PersonalPubSubHandler extends PubSubHandler {
 
     private void roomCreateResponse (String channel, Object object) {
         RedisMessage redisMessage = (RedisMessage) object;
-        RoomMetadata roomMetadata = convertMessageToDto(redisMessage.payload(), RoomMetadata.class);
+        RoomMetadata roomMetadata = jsonSerializer.deserialize((String) redisMessage.payload(), RoomMetadata.class);
         messagingTemplate.convertAndSend(channel, roomMetadata);
     }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
@@ -39,10 +39,7 @@ public class RoomController {
         roomUserService.checkUserNotInAnyRoom(userId);
         RoomMetadata metadata = roomService.createRoom(request, userId);
 
-        objectRedisTemplate.convertAndSend(ROOM_CREATE_INFO,
-                new RedisMessage(userId, ROOM_CREATE_INFO, metadata)); //방 목록 생성 브로드 캐스트 용
-        objectRedisTemplate.convertAndSend(PERSONAL_ROOM_CREATE_RESPONSE,
-                new RedisMessage(userId, PERSONAL_ROOM_CREATE_RESPONSE, metadata)); //본인의 대기방 생성 확인 용
+        roomService.broadcastRoomInfo(userId, metadata);
     }
 
     @MessageMapping("/join/{roomId}")

--- a/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
@@ -27,26 +27,23 @@ public class RoomController {
 
     private final RoomService roomService;
     private final RoomUserService roomUserService;
-    private final UserService userService;
-
 
     @MessageMapping("/create")
     public void createRoom(@Valid @Payload CreateRoomRequest request, @AuthenticationPrincipal SecurityUserDetails userDetails) {
-        String userId = userDetails.getUsername();
-
+        String userId = userDetails.getUuid();
         roomUserService.checkUserNotInAnyRoom(userId);
         RoomMetadata metadata = roomService.createRoom(request, userId);
-
         roomService.broadcastRoomInfo(userId, metadata);
     }
 
     @MessageMapping("/join/{roomId}")
     public void joinRoom(@DestinationVariable String roomId, @AuthenticationPrincipal SecurityUserDetails userDetails){
-        String userId = userDetails.getUsername();
-
-        UserInfoRes userInfoRes = userService.getUserInfo(userDetails);
-
-        RoomUserInfo roomUserInfo = RoomUserInfo.fromDTO(userDetails.getUuid(), userInfoRes);
+        String userId = userDetails.getUuid();
+        RoomUserInfo roomUserInfo = RoomUserInfo.builder().
+                userId(userId).
+                nickname(userDetails.getNickname()).
+                ready(false).
+                build();
 
         // room에 들어오면
         roomUserService.joinRoom(roomUserInfo, roomId);

--- a/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
@@ -12,14 +12,12 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import socket_server.common.config.RedisMessage;
 import socket_server.domain.room.dto.CreateRoomRequest;
 import socket_server.domain.room.model.RoomMetadata;
 import socket_server.domain.room.model.RoomUserInfo;
 import socket_server.domain.room.service.RoomService;
 import socket_server.domain.room.service.RoomUserService;
 
-import static socket_server.common.constants.WebSocketConstants.*;
 
 @Slf4j
 @Controller
@@ -43,7 +41,7 @@ public class RoomController {
     }
 
     @MessageMapping("/join/{roomId}")
-    public void joinRoom(@DestinationVariable String roomId, @AuthenticationPrincipal SecurityUserDetails userDetails) throws JsonProcessingException {
+    public void joinRoom(@DestinationVariable String roomId, @AuthenticationPrincipal SecurityUserDetails userDetails){
         String userId = userDetails.getUsername();
 
         UserInfoRes userInfoRes = userService.getUserInfo(userDetails);

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomPubSubHandler.java
@@ -11,6 +11,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import socket_server.common.config.RedisMessage;
 import socket_server.common.listener.PubSubHandler;
+import socket_server.common.util.JsonSerializer;
 import socket_server.domain.room.model.RoomMetadata;
 import socket_server.domain.room.model.RoomUserInfo;
 
@@ -24,11 +25,11 @@ import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
 @Qualifier("roomPubSubHandler")
 public class RoomPubSubHandler extends PubSubHandler {
 
-    private final ObjectMapper objectMapper;
+    private final JsonSerializer jsonSerializer;
 
-    public RoomPubSubHandler(SimpMessagingTemplate messagingTemplate, ObjectMapper objectMapper) {
+    public RoomPubSubHandler(SimpMessagingTemplate messagingTemplate, JsonSerializer jsonSerializer) {
         super(messagingTemplate);
-        this.objectMapper = objectMapper;
+        this.jsonSerializer = jsonSerializer;
     }
 
     @Override
@@ -39,14 +40,14 @@ public class RoomPubSubHandler extends PubSubHandler {
 
     private void roomCreateInfo(String channel, Object object) {
         RedisMessage redisMessage = (RedisMessage) object;
-        RoomMetadata roomMetadata = convertMessageToDto(redisMessage.payload(), RoomMetadata.class);
+        RoomMetadata roomMetadata = jsonSerializer.deserialize((String) redisMessage.payload(), RoomMetadata.class);
         messagingTemplate.convertAndSend(channel, roomMetadata);
     }
 
     private void roomJoin(String channel, Object object) {
         RedisMessage redisMessage = (RedisMessage) object;
         // payload : List<RoomUserInfo>
-        List<RoomUserInfo> roomUserInfoList = convertMessageToList(redisMessage.payload(), RoomUserInfo.class);
+        List<RoomUserInfo> roomUserInfoList = jsonSerializer.deserializeList((String) redisMessage.payload(), RoomUserInfo.class);
         messagingTemplate.convertAndSend(channel, roomUserInfoList);
     }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomPubSubHandler.java
@@ -33,14 +33,14 @@ public class RoomPubSubHandler extends PubSubHandler {
 
     private void roomCreateInfo(String channel, Object object) {
         RedisMessage redisMessage = (RedisMessage) object;
-        RoomMetadata roomMetadata = jsonSerializer.deserialize((String) redisMessage.payload(), RoomMetadata.class);
+        RoomMetadata roomMetadata = jsonSerializer.deserialize(redisMessage.payload(), RoomMetadata.class);
         messagingTemplate.convertAndSend(channel, roomMetadata);
     }
 
     private void roomJoin(String channel, Object object) {
         RedisMessage redisMessage = (RedisMessage) object;
         // payload : List<RoomUserInfo>
-        List<RoomUserInfo> roomUserInfoList = jsonSerializer.deserializeList((String) redisMessage.payload(), RoomUserInfo.class);
+        List<RoomUserInfo> roomUserInfoList = jsonSerializer.deserializeList(redisMessage.payload(), RoomUserInfo.class);
         messagingTemplate.convertAndSend(channel, roomUserInfoList);
     }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomPubSubHandler.java
@@ -1,10 +1,5 @@
 package socket_server.domain.room.handler;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gotcha_common.exception.CustomException;
-import gotcha_common.exception.exceptionCode.GlobalExceptionCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -25,11 +20,9 @@ import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
 @Qualifier("roomPubSubHandler")
 public class RoomPubSubHandler extends PubSubHandler {
 
-    private final JsonSerializer jsonSerializer;
 
     public RoomPubSubHandler(SimpMessagingTemplate messagingTemplate, JsonSerializer jsonSerializer) {
-        super(messagingTemplate);
-        this.jsonSerializer = jsonSerializer;
+        super(messagingTemplate, jsonSerializer);
     }
 
     @Override

--- a/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomUserInfo.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomUserInfo.java
@@ -1,0 +1,26 @@
+package socket_server.domain.room.model;
+
+import gotcha_user.dto.UserInfoRes;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RoomUserInfo {
+
+    private String userId;
+    private String nickname;
+    private boolean ready;
+
+
+    public static RoomUserInfo fromDTO(String userId, UserInfoRes userInfoRes){
+        RoomUserInfo roomUserInfo = new RoomUserInfo();
+        roomUserInfo.userId = userId;
+        roomUserInfo.nickname = userInfoRes.nickname();
+        roomUserInfo.ready = false;
+        return roomUserInfo;
+    }
+
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomUserInfo.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomUserInfo.java
@@ -1,26 +1,18 @@
 package socket_server.domain.room.model;
 
-import gotcha_user.dto.UserInfoRes;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class RoomUserInfo {
 
     private String userId;
     private String nickname;
     private boolean ready;
-
-
-    public static RoomUserInfo fromDTO(String userId, UserInfoRes userInfoRes){
-        RoomUserInfo roomUserInfo = new RoomUserInfo();
-        roomUserInfo.userId = userId;
-        roomUserInfo.nickname = userInfoRes.nickname();
-        roomUserInfo.ready = false;
-        return roomUserInfo;
-    }
 
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomRepository.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomRepository.java
@@ -1,0 +1,29 @@
+package socket_server.domain.room.repository;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+
+@Repository
+public class RoomRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RoomRepository(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void saveRoomData(String roomId, Map<String, String> roomData) {
+        redisTemplate.opsForHash().putAll(getRoomKey(roomId), roomData);
+    }
+
+    public Map<Object, Object> getRoomData(String roomId) {
+        return redisTemplate.opsForHash().entries(getRoomKey(roomId));
+    }
+
+    private String getRoomKey(String roomId) {
+        return "room:" + roomId;
+    }
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomUserRepository.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomUserRepository.java
@@ -1,0 +1,75 @@
+package socket_server.domain.room.repository;
+
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import socket_server.common.util.JsonSerializer;
+import socket_server.domain.room.model.RoomUserInfo;
+
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class RoomUserRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final JsonSerializer jsonSerializer;
+
+    public RoomUserRepository(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate, JsonSerializer jsonSerializer) {
+        this.redisTemplate = redisTemplate;
+        this.jsonSerializer = jsonSerializer;
+    }
+
+    private String roomUserKey(String roomId) {
+        return "room:" + roomId + ":users";
+    }
+
+    private String userRoomKey(String userId) {
+        return "user:" + userId + ":room";
+    }
+
+
+    public void saveUserToRoom(RoomUserInfo roomUserInfo, String roomId) {
+
+        String parsedJson = jsonSerializer.serialize(roomUserInfo);
+        /**
+         * key : room:roomId:users
+         * field: userId
+         * value: RoomUserInfo
+         * -------------------------
+         * key: user:userId:room
+         * string: roomId
+         */
+        redisTemplate.execute((RedisCallback<Object>) connection -> {
+            connection.multi();
+            connection.hashCommands().hSet(
+                    roomUserKey(roomId).getBytes(),
+                    roomUserInfo.getUserId().getBytes(),
+                    parsedJson.getBytes());
+            connection.stringCommands().set(userRoomKey(roomUserInfo.getUserId()).getBytes(), roomId.getBytes());
+            return connection.exec();
+        });
+    }
+
+    public List<RoomUserInfo> findUsersByRoomId(String roomId) {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(roomUserKey(roomId));
+        return entries.values().stream().map(string -> jsonSerializer.deserialize((String) string, RoomUserInfo.class)).toList();
+    }
+
+    public void removeUserFromRoom(String roomId, String userId) {
+        redisTemplate.execute((RedisCallback<Object>) connection -> {
+            connection.multi();
+            connection.sRem(roomUserKey(roomId).getBytes(), userId.getBytes());
+            connection.sRem(userRoomKey(userId).getBytes(), roomId.getBytes());
+            return connection.exec();
+        });
+    }
+
+    public String findRoomIdByUserId(String userId) {
+        return redisTemplate.opsForValue().get(userRoomKey(userId));
+    }
+
+
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomUserRepository.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomUserRepository.java
@@ -30,7 +30,6 @@ public class RoomUserRepository {
         return "user:" + userId + ":room";
     }
 
-
     public void saveUserToRoom(RoomUserInfo roomUserInfo, String roomId) {
 
         String parsedJson = jsonSerializer.serialize(roomUserInfo);
@@ -55,7 +54,7 @@ public class RoomUserRepository {
 
     public List<RoomUserInfo> findUsersByRoomId(String roomId) {
         Map<Object, Object> entries = redisTemplate.opsForHash().entries(roomUserKey(roomId));
-        return entries.values().stream().map(string -> jsonSerializer.deserialize((String) string, RoomUserInfo.class)).toList();
+        return entries.values().stream().map(raw -> jsonSerializer.deserialize(raw, RoomUserInfo.class)).toList();
     }
 
     public void removeUserFromRoom(String roomId, String userId) {

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -68,5 +68,4 @@ public class RoomService {
     }
 
 
-
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -48,6 +48,8 @@ public class RoomService {
         return RoomMetadata.fromRedisMap(roomId, fields);
     }
 
+
+
     private String getRoomKey(String roomId) {
         return "room:"  + roomId;
     }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -3,24 +3,36 @@ package socket_server.domain.room.service;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import socket_server.common.config.RedisMessage;
+import socket_server.common.util.JsonSerializer;
 import socket_server.domain.room.RoomField.RoomField;
 import socket_server.domain.room.dto.CreateRoomRequest;
 import socket_server.domain.room.model.RoomMetadata;
+import socket_server.domain.room.repository.RoomRepository;
 
 import java.util.Map;
+
+import static socket_server.common.constants.WebSocketConstants.PERSONAL_ROOM_CREATE_RESPONSE;
+import static socket_server.common.constants.WebSocketConstants.ROOM_CREATE_INFO;
 
 @Service
 public class RoomService {
 
     private final RoomIdService roomIdService;
-    private final RedisTemplate<String, String> redisTemplate;
+    private final JsonSerializer jsonSerializer;
+    private final RoomRepository roomRepository;
+    private final RedisTemplate<String, Object> objectRedisTemplate;
 
     public RoomService(
             RoomIdService roomIdService,
-            @Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate
+            RoomRepository roomRepository,
+            RedisTemplate<String, Object> objectRedisTemplate,
+            JsonSerializer jsonSerializer
     ) {
         this.roomIdService = roomIdService;
-        this.redisTemplate = redisTemplate;
+        this.roomRepository = roomRepository;
+        this.objectRedisTemplate = objectRedisTemplate;
+        this.jsonSerializer = jsonSerializer;
     }
 
     //todo : lua 스크립트 적용
@@ -39,18 +51,22 @@ public class RoomService {
                 RoomField.GAME_MODE.getRedisField(), request.gameMode().name()
         );
 
-        redisTemplate.opsForHash().putAll(getRoomKey(roomId), roomData);
+        roomRepository.saveRoomData(roomId, roomData);
         return getRoomInfo(roomId);
     }
 
+    public void broadcastRoomInfo(String userId, RoomMetadata metadata) {
+        objectRedisTemplate.convertAndSend(ROOM_CREATE_INFO,
+                new RedisMessage(userId, ROOM_CREATE_INFO, jsonSerializer.serialize(metadata))); //방 목록 생성 브로드 캐스트 용
+        objectRedisTemplate.convertAndSend(PERSONAL_ROOM_CREATE_RESPONSE,
+                new RedisMessage(userId, PERSONAL_ROOM_CREATE_RESPONSE, jsonSerializer.serialize(metadata))); //본인의 대기방 생성 확인 용
+    }
+
     public RoomMetadata getRoomInfo(String roomId) {
-        Map<Object, Object> fields = redisTemplate.opsForHash().entries(getRoomKey(roomId));
+        Map<Object, Object> fields = roomRepository.getRoomData(roomId);
         return RoomMetadata.fromRedisMap(roomId, fields);
     }
 
 
 
-    private String getRoomKey(String roomId) {
-        return "room:"  + roomId;
-    }
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -1,22 +1,29 @@
 package socket_server.domain.room.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gotcha_common.exception.CustomException;
+import gotcha_common.exception.exceptionCode.GlobalExceptionCode;
+import gotcha_user.dto.UserInfoRes;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import socket_server.common.exception.room.RoomExceptionCode;
+import socket_server.domain.room.model.RoomUserInfo;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class RoomUserService {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public RoomUserService(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+    private final ObjectMapper objectMapper;
+
+    public RoomUserService(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate, ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
         this.redisTemplate = redisTemplate;
     }
 
@@ -25,19 +32,22 @@ public class RoomUserService {
     }
 
     private String userRoomKey(String userId) {
-        return "user:" + userId + ":rooms";
+        return "user:" + userId + ":room";
     }
 
-    private String userCurrentRoomKey(String userId) {
-        return "user:" + userId + ":currentRoom";
-    }
+    public void joinRoom(RoomUserInfo roomUserInfo, String roomId) throws JsonProcessingException {
+        checkUserNotInAnyRoom(roomUserInfo.getUserId()); // after check not in any room
 
-    public void joinRoom(String userId, String roomId) {
+        String parsedJson = objectMapper.writeValueAsString(roomUserInfo);
+
+        // RoomUserInfo Redis에 저장
         redisTemplate.execute((RedisCallback<Object>) connection -> {
             connection.multi();
-            connection.sAdd(roomUserKey(roomId).getBytes(), userId.getBytes());
-            connection.sAdd(userRoomKey(userId).getBytes(), roomId.getBytes());
-            connection.set(userCurrentRoomKey(userId).getBytes(), roomId.getBytes());
+            connection.hashCommands().hSet(
+                    roomUserKey(roomId).getBytes(),
+                    roomUserInfo.getUserId().getBytes(),
+                    parsedJson.getBytes());
+            connection.stringCommands().set(userRoomKey(roomUserInfo.getUserId()).getBytes(), roomId.getBytes());
             return connection.exec();
         });
     }
@@ -47,25 +57,34 @@ public class RoomUserService {
             connection.multi();
             connection.sRem(roomUserKey(roomId).getBytes(), userId.getBytes());
             connection.sRem(userRoomKey(userId).getBytes(), roomId.getBytes());
-            connection.del(userCurrentRoomKey(userId).getBytes());
             return connection.exec();
         });
     }
+
 
     public boolean isUserInRoom(String userId, String roomId) {
         return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(roomUserKey(roomId), userId));
     }
 
-    public List<String> getUsersInRoom(String roomId) {
-        return new ArrayList<>(redisTemplate.opsForSet().members(roomUserKey(roomId)));
+    public List<RoomUserInfo> getUsersInRoom(String roomId) {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(roomUserKey(roomId));
+
+        return entries.values().stream().map(string -> {
+            try {
+                return objectMapper.readValue((String) string, RoomUserInfo.class);
+            } catch (JsonProcessingException e) {
+                throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
+            }
+        }).toList();
     }
 
-    public void checkUserNotInAnyRoom (String userId) {
-        String value = redisTemplate.opsForValue().get(userCurrentRoomKey(userId));
-
+    public void checkUserNotInAnyRoom(String userId) {
+        String key = userRoomKey(userId); // 예: user:{uuid}:room
+        String value = redisTemplate.opsForValue().get(key);
         if (value != null) {
             throw new CustomException(RoomExceptionCode.USER_ALREADY_IN_ANOTHER_ROOM);
         }
+
     }
 }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -1,90 +1,55 @@
 package socket_server.domain.room.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import gotcha_common.exception.CustomException;
-import gotcha_common.exception.exceptionCode.GlobalExceptionCode;
-import gotcha_user.dto.UserInfoRes;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.redis.connection.DataType;
-import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import socket_server.common.config.RedisMessage;
 import socket_server.common.exception.room.RoomExceptionCode;
+import socket_server.common.util.JsonSerializer;
 import socket_server.domain.room.model.RoomUserInfo;
+import socket_server.domain.room.repository.RoomUserRepository;
 
 import java.util.*;
+
+import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
 
 @Service
 public class RoomUserService {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, Object> objectRedisTemplate;
+    private final JsonSerializer jsonSerializer;
+    private final RoomUserRepository roomUserRepository;
 
-    private final ObjectMapper objectMapper;
-
-    public RoomUserService(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate, ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-        this.redisTemplate = redisTemplate;
+    public RoomUserService( RedisTemplate<String, Object> objectRedisTemplate, RoomUserRepository roomUserRepository, JsonSerializer jsonSerializer) {
+        this.jsonSerializer = jsonSerializer;
+        this.roomUserRepository = roomUserRepository;
+        this.objectRedisTemplate = objectRedisTemplate;
     }
 
-    private String roomUserKey(String roomId) {
-        return "room:" + roomId + ":users";
-    }
-
-    private String userRoomKey(String userId) {
-        return "user:" + userId + ":room";
-    }
-
-    public void joinRoom(RoomUserInfo roomUserInfo, String roomId) throws JsonProcessingException {
+    public void joinRoom(RoomUserInfo roomUserInfo, String roomId) {
         checkUserNotInAnyRoom(roomUserInfo.getUserId()); // after check not in any room
-
-        String parsedJson = objectMapper.writeValueAsString(roomUserInfo);
-
-        // RoomUserInfo Redis에 저장
-        redisTemplate.execute((RedisCallback<Object>) connection -> {
-            connection.multi();
-            connection.hashCommands().hSet(
-                    roomUserKey(roomId).getBytes(),
-                    roomUserInfo.getUserId().getBytes(),
-                    parsedJson.getBytes());
-            connection.stringCommands().set(userRoomKey(roomUserInfo.getUserId()).getBytes(), roomId.getBytes());
-            return connection.exec();
-        });
+        roomUserRepository.saveUserToRoom(roomUserInfo, roomId);
     }
 
-    public void leaveRoom(String userId, String roomId) {
-        redisTemplate.execute((RedisCallback<Object>) connection -> {
-            connection.multi();
-            connection.sRem(roomUserKey(roomId).getBytes(), userId.getBytes());
-            connection.sRem(userRoomKey(userId).getBytes(), roomId.getBytes());
-            return connection.exec();
-        });
-    }
+    public void broadcastUserList(String roomId, String userId){
+        // 그 방에 누가 있는지 조회 후
+        List<RoomUserInfo> userList = roomUserRepository.findUsersByRoomId(roomId);
 
+        // 해당 방에 누가 있는지를 BroadCast
+        objectRedisTemplate.convertAndSend(ROOM_JOIN+roomId,
+                new RedisMessage(
+                        userId,
+                        ROOM_JOIN+roomId,
+                        jsonSerializer.serialize(userList)));
 
-    public boolean isUserInRoom(String userId, String roomId) {
-        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(roomUserKey(roomId), userId));
-    }
-
-    public List<RoomUserInfo> getUsersInRoom(String roomId) {
-        Map<Object, Object> entries = redisTemplate.opsForHash().entries(roomUserKey(roomId));
-
-        return entries.values().stream().map(string -> {
-            try {
-                return objectMapper.readValue((String) string, RoomUserInfo.class);
-            } catch (JsonProcessingException e) {
-                throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
-            }
-        }).toList();
     }
 
     public void checkUserNotInAnyRoom(String userId) {
-        String key = userRoomKey(userId); // 예: user:{uuid}:room
-        String value = redisTemplate.opsForValue().get(key);
+        String value = roomUserRepository.findRoomIdByUserId(userId);
         if (value != null) {
             throw new CustomException(RoomExceptionCode.USER_ALREADY_IN_ANOTHER_ROOM);
         }
-
     }
 }
 


### PR DESCRIPTION
# feat: 방 입장 기능 구현

## 📝 개요  

방 입장 기능을 구현하였습니다.

추가로 기존에 작성되어 있던 방 생성 관련 코드들을 리팩토링 하였습니다.

---

## ⚙️ 구현 내용  

기존에 작성되어있던 방 생성을 포함하여 Redis에 저장될 Room-User 접근 관련 코드들을 

Redis 접근 시 Repository 계층에서, 로직 처리 시 Service 계층에서 처리하도록 리팩토링 하였습니다.

데이터 저장을 위한 SocketStringRedisTemplate은 Repository 계층에,

데이터 Publish를 위한 objectRedisTemplate은 Service 계층에 주입되어 사용하도록 했습니다.

```
// RoomUserService.java
public void joinRoom(RoomUserInfo roomUserInfo, String roomId) {
    checkUserNotInAnyRoom(roomUserInfo.getUserId()); // after check not in any room
    roomUserRepository.saveUserToRoom(roomUserInfo, roomId);
}

public void broadcastUserList(String roomId, String userId){
    // 그 방에 누가 있는지 조회 후
    List<RoomUserInfo> userList = roomUserRepository.findUsersByRoomId(roomId);

    // 해당 방에 누가 있는지를 BroadCast
    objectRedisTemplate.convertAndSend(ROOM_JOIN+roomId,
            new RedisMessage(
                    userId,
                    ROOM_JOIN+roomId,
                    jsonSerializer.serialize(userList)));

}

//RoomUserRepository.java
public List<RoomUserInfo> findUsersByRoomId(String roomId) {
    Map<Object, Object> entries = redisTemplate.opsForHash().entries(roomUserKey(roomId));
    return entries.values().stream().map(raw -> jsonSerializer.deserialize(raw, RoomUserInfo.class)).toList();
}
```

PubSubHandler 추상클래스의 convertMessageToDto를 전역 유틸 클래스 JsonSerializer로 작성했습니다.

convertMessageToDto는 응답이 단일 클래스인 경우만 사용 가능했고,

List<T> 와 같은 컬렉션의 경우 사용이 불가능해 이 부분을 추가해주었습니다.

```
// String(JSON) to List
public <T> List<T> deserializeList(Object raw, Class<T> elementClass) {
    try {
        JavaType type = objectMapper.getTypeFactory().constructCollectionType(List.class, elementClass);
        if(raw instanceof String rawstr) {
            return objectMapper.readValue(rawstr, type);
        }
        return objectMapper.convertValue(raw, type);
    } catch (JsonProcessingException e) {
        throw new CustomException(GlobalExceptionCode.INVALID_MESSAGE_FORMAT);
    }
}
```

또한 같이 PubSubHandler 클래스 밖에서 JSON 직렬화/역직렬화가 필요한 경우도 있었기 때문에 전역 유틸 클래스 JsonSerializer를 작성하여 이를 필요한 경우 주입받도록 했습니다.

```
//RoomUserRepository.java
public List<RoomUserInfo> findUsersByRoomId(String roomId) {
    Map<Object, Object> entries = redisTemplate.opsForHash().entries(roomUserKey(roomId));
    return entries.values().stream().map(raw -> jsonSerializer.deserialize(raw, RoomUserInfo.class)).toList();
}

```
---
## 📎 기타

```
Caused by: java.lang.IllegalArgumentException: Cannot construct instance of `socket_server.domain.room.model.RoomUserInfo` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('java.util.ImmutableCollections$ListN')
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: java.util.ArrayList[0])
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4636)
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4587)
	at socket_server.common.util.JsonSerializer.deserializeList(JsonSerializer.java:53)
	at socket_server.domain.room.handler.RoomPubSubHandler.roomJoin(RoomPubSubHandler.java:43)
	at socket_server.common.listener.PubSubHandler.onMessage(PubSubHandler.java:42)
	at socket_server.common.config.RedisIntegrationConfig.lambda$roomMessageFlow$2(RedisIntegrationConfig.java:157)
	at org.springframework.integration.handler.LambdaMessageProcessor.invokeMethod(LambdaMessageProcessor.java:208)
	at org.springframework.integration.handler.LambdaMessageProcessor.processMessage(LambdaMessageProcessor.java:121)
	at org.springframework.integration.handler.ServiceActivatingHandler.handleRequestMessage(ServiceActivatingHandler.java:93)
	at org.springframework.integration.handler.AbstractReplyProducingMessageHandler.handleMessageInternal(AbstractReplyProducingMessageHandler.java:146)
	at org.springframework.integration.handler.AbstractMessageHandler.doHandleMessage(AbstractMessageHandler.java:105)
	... 8 more

```


objectRedisTemplate.convertAndMessage() 의 인자로 List<RoomUserInfo> 타입의 객체를 넣어주었을 때 위와 같은 에러가 발생했습니다.

실제로 Redis에 넘어간 데이터는 List<RoomUserInfo>의 참조가 되어서 `'java.util.ImmutableCollections$ListN'`  문자열을 다시 역직렬화 하려다 발생한 에러로, RedisMessage의 Payload에도 객체들을 문자열로 직렬화 하여 넘길 필요성을 느끼게 되었습니다. 

이에 따라 현재 작성되어 있던 모든 objectRedisTemplate.convertAndMessage() 에서 사용된 RedisMessage의 Payload를 String으로 직렬화시키도록 수정했습니다. (RedisMessage.payload도 String 타입으로 수정했습니다)


---

## 🧪 테스트 결과  
### room 생성 후 입장 1
![roomjoin_1](https://github.com/user-attachments/assets/e6cb2e71-d0df-4f6b-af70-dcfe3964ad21)

### room 입장 2
![roomjoin_2](https://github.com/user-attachments/assets/1422350d-14b4-40df-b577-528b068c9879)

### room 입장 3
![roomjoin_3](https://github.com/user-attachments/assets/8a4bdd0b-b3cc-494a-9b06-dc7d9c8e57b0)

---
