### PR TITLE
feat: 대기방 소켓 통일 및 채팅 구현

### DIFF
--- a/gotcha-socket/src/main/java/socket_server/common/config/RedisIntegrationConfig.java
+++ b/gotcha-socket/src/main/java/socket_server/common/config/RedisIntegrationConfig.java
@@ -40,6 +40,7 @@ import static socket_server.common.constants.WebSocketConstants.GAME_READY_CHANN
 import static socket_server.common.constants.WebSocketConstants.GAME_START_CHANNEL;
 import static socket_server.common.constants.WebSocketConstants.PERSONAL_PREFIX;
 import static socket_server.common.constants.WebSocketConstants.ROOM_CREATE_INFO;
+import static socket_server.common.constants.WebSocketConstants.ROOM_EVENT;
 import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
 import static socket_server.common.constants.WebSocketConstants.ROOM_LEAVE;
 import static socket_server.common.constants.WebSocketConstants.ROOM_LIST_INFO;
@@ -118,7 +119,7 @@ public class RedisIntegrationConfig {
         RedisInboundChannelAdapter adapter = new RedisInboundChannelAdapter(cf);
         adapter.setTopicPatterns(
                 // 개인 유저 메시지
-                PERSONAL_PREFIX +"*",
+                PERSONAL_PREFIX + "*",
                 // 채팅
                 CHAT_ALL_CHANNEL,                     // /sub/chat/all
                 CHAT_PRIVATE_CHANNEL + "*",          // /sub/chat/private/*
@@ -130,6 +131,7 @@ public class RedisIntegrationConfig {
                 ROOM_LEAVE + "*",                    // /sub/room/leave/*
                 ROOM_UPDATE + "*",                   // /sub/room/update/*
                 ROOM_JOIN + "*",                     // /sub/room/join/*
+                ROOM_EVENT + "*",
 
 
                 // 게임

--- a/gotcha-socket/src/main/java/socket_server/common/constants/WebSocketConstants.java
+++ b/gotcha-socket/src/main/java/socket_server/common/constants/WebSocketConstants.java
@@ -9,6 +9,7 @@ public interface WebSocketConstants {
 
     //대기방 관련 채널
     String ROOM_PREFIX = "/sub/room/";
+    String ROOM_EVENT = ROOM_PREFIX + "event/";
     String ROOM_LIST_INFO = ROOM_PREFIX + "list/info";
     String ROOM_JOIN = ROOM_PREFIX+"join/"; // + roomId
     String ROOM_LEAVE = ROOM_PREFIX+"leave/"; // + roomId

--- a/gotcha-socket/src/main/java/socket_server/common/exception/room/RoomExceptionCode.java
+++ b/gotcha-socket/src/main/java/socket_server/common/exception/room/RoomExceptionCode.java
@@ -13,7 +13,8 @@ public enum RoomExceptionCode implements ExceptionCode {
     INVALID_ROOM_ID(HttpStatus.BAD_REQUEST, "ROOM_400_004", "유효하지 않은 고유 방 코드 입니다."),
     ROOM_ID_EXHAUSTED(HttpStatus.SERVICE_UNAVAILABLE, "GLOBAL-503-001", "사용 가능한 방 코드가 모두 소진되었습니다. 서버 팀에 문의해주세요."),
     INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, "ROOM_400_005", "유효하지 않은 이벤트 타입입니다."),
-    PASSWORD_REQUIRED_BUT_MISSING(HttpStatus.BAD_REQUEST, "ROOM_400_006", "비밀번호 값이 없습니다.");
+    PASSWORD_REQUIRED_BUT_MISSING(HttpStatus.BAD_REQUEST, "ROOM_400_006", "비밀번호 값이 없습니다."),
+    INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "ROOM_400_007", "비밀번호가 잘못 되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha-socket/src/main/java/socket_server/common/exception/room/RoomExceptionCode.java
+++ b/gotcha-socket/src/main/java/socket_server/common/exception/room/RoomExceptionCode.java
@@ -11,7 +11,8 @@ public enum RoomExceptionCode implements ExceptionCode {
     USER_NOT_IN_ROOM(HttpStatus.BAD_REQUEST, "ROOM_400_003", "방에 존재하지 않는 유저입니다."),
     NOT_ROOM_OWNER(HttpStatus.FORBIDDEN, "ROOM_403_001", "방장 권한이 없습니다."),
     INVALID_ROOM_ID(HttpStatus.BAD_REQUEST, "ROOM_400_004", "유효하지 않은 고유 방 코드 입니다."),
-    ROOM_ID_EXHAUSTED(HttpStatus.SERVICE_UNAVAILABLE, "GLOBAL-503-001", "사용 가능한 방 코드가 모두 소진되었습니다. 서버 팀에 문의해주세요.");
+    ROOM_ID_EXHAUSTED(HttpStatus.SERVICE_UNAVAILABLE, "GLOBAL-503-001", "사용 가능한 방 코드가 모두 소진되었습니다. 서버 팀에 문의해주세요."),
+    INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, "ROOM_400_005", "유효하지 않은 이벤트 타입입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha-socket/src/main/java/socket_server/common/exception/room/RoomExceptionCode.java
+++ b/gotcha-socket/src/main/java/socket_server/common/exception/room/RoomExceptionCode.java
@@ -12,7 +12,8 @@ public enum RoomExceptionCode implements ExceptionCode {
     NOT_ROOM_OWNER(HttpStatus.FORBIDDEN, "ROOM_403_001", "방장 권한이 없습니다."),
     INVALID_ROOM_ID(HttpStatus.BAD_REQUEST, "ROOM_400_004", "유효하지 않은 고유 방 코드 입니다."),
     ROOM_ID_EXHAUSTED(HttpStatus.SERVICE_UNAVAILABLE, "GLOBAL-503-001", "사용 가능한 방 코드가 모두 소진되었습니다. 서버 팀에 문의해주세요."),
-    INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, "ROOM_400_005", "유효하지 않은 이벤트 타입입니다.");
+    INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, "ROOM_400_005", "유효하지 않은 이벤트 타입입니다."),
+    PASSWORD_REQUIRED_BUT_MISSING(HttpStatus.BAD_REQUEST, "ROOM_400_006", "비밀번호 값이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/dto/ChatMessage.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/dto/ChatMessage.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record ChatMessage(
         String nickname,
         String content,
-        ChatType type,
+        ChatType chatType,
         LocalDateTime sentAt
 ) {
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/RoomField/RoomField.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/RoomField/RoomField.java
@@ -12,7 +12,8 @@ public enum RoomField {
     GAME_MODE("gameMode"),
     MIN("min"),
     MAX("max"),
-    OWNER("owner");
+    OWNER("owner"),
+    UUID("uuid");
 
     private final String redisField;
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/RoomField/RoomField.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/RoomField/RoomField.java
@@ -13,7 +13,7 @@ public enum RoomField {
     MIN("min"),
     MAX("max"),
     OWNER("owner"),
-    UUID("uuid");
+    OWNER_UUID("ownerUuid");
 
     private final String redisField;
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
@@ -13,7 +13,6 @@ import socket_server.domain.room.dto.CreateRoomRequest;
 import socket_server.domain.room.dto.RoomReq;
 import socket_server.domain.room.handler.RoomEventDispatcher;
 import socket_server.domain.room.service.RoomService;
-import socket_server.domain.room.service.RoomUserService;
 
 @Slf4j
 @Controller
@@ -22,7 +21,6 @@ import socket_server.domain.room.service.RoomUserService;
 public class RoomController {
 
     private final RoomService roomService;
-    private final RoomUserService roomUserService;
     private final RoomEventDispatcher dispatcher;
 
     @MessageMapping("/create")
@@ -35,9 +33,5 @@ public class RoomController {
                      @Valid @Payload RoomReq request,
                      @AuthenticationPrincipal SecurityUserDetails userDetails) {
         dispatcher.dispatch(request, roomId, userDetails);
-    }
-
-    public void joinRoom(String roomId, String userUuid, String nickname){
-        roomUserService.joinAndBroadcast(roomId, userUuid, nickname);
     }
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Controller;
 import socket_server.common.exception.room.RoomExceptionCode;
 import socket_server.domain.room.dto.CreateRoomRequest;
 import socket_server.domain.room.dto.RoomReq;
-import socket_server.domain.room.model.RoomMetadata;
 import socket_server.domain.room.service.RoomService;
 import socket_server.domain.room.service.RoomUserService;
 
@@ -29,10 +28,7 @@ public class RoomController {
 
     @MessageMapping("/create")
     public void createRoom(@Valid @Payload CreateRoomRequest request, @AuthenticationPrincipal SecurityUserDetails userDetails) {
-        String userUuid = userDetails.getUuid();
-        roomUserService.checkUserNotInAnyRoom(userUuid);
-        RoomMetadata metadata = roomService.createRoom(request, userUuid);
-        roomService.broadcastRoomInfo(userUuid, metadata);
+        roomService.handleCreateRoom(request, userDetails);
     }
 
     @MessageMapping("/{roomId}")
@@ -46,10 +42,6 @@ public class RoomController {
     }
 
     public void joinRoom(String roomId, String userUuid, String nickname){
-        // room에 들어오면
-        roomUserService.joinRoom(roomId, userUuid, nickname);
-
-        // 그 방에 있는 새로운 userList broadcast
-        roomUserService.broadcastUserList(roomId, userUuid);
+        roomUserService.joinAndBroadcast(roomId, userUuid, nickname);
     }
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/controller/RoomController.java
@@ -1,6 +1,5 @@
 package socket_server.domain.room.controller;
 
-import gotcha_common.exception.CustomException;
 import gotcha_domain.auth.SecurityUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,12 +9,11 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import socket_server.common.exception.room.RoomExceptionCode;
 import socket_server.domain.room.dto.CreateRoomRequest;
 import socket_server.domain.room.dto.RoomReq;
+import socket_server.domain.room.handler.RoomEventDispatcher;
 import socket_server.domain.room.service.RoomService;
 import socket_server.domain.room.service.RoomUserService;
-
 
 @Slf4j
 @Controller
@@ -25,6 +23,7 @@ public class RoomController {
 
     private final RoomService roomService;
     private final RoomUserService roomUserService;
+    private final RoomEventDispatcher dispatcher;
 
     @MessageMapping("/create")
     public void createRoom(@Valid @Payload CreateRoomRequest request, @AuthenticationPrincipal SecurityUserDetails userDetails) {
@@ -35,10 +34,7 @@ public class RoomController {
     public void room(@DestinationVariable String roomId,
                      @Valid @Payload RoomReq request,
                      @AuthenticationPrincipal SecurityUserDetails userDetails) {
-        switch (request.eventType()) {
-            case JOIN -> joinRoom(roomId, userDetails.getUuid(), userDetails.getNickname());
-            default -> throw new CustomException(RoomExceptionCode.INVALID_EVENT_TYPE);
-        }
+        dispatcher.dispatch(request, roomId, userDetails);
     }
 
     public void joinRoom(String roomId, String userUuid, String nickname){

--- a/gotcha-socket/src/main/java/socket_server/domain/room/dto/CreateRoomRequest.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/dto/CreateRoomRequest.java
@@ -27,8 +27,5 @@ public record CreateRoomRequest(
         GameMode gameMode,
 
         @Min(1) @Max(5)
-        int roundCount,
-
-        @NotNull(message = "식별 번호는 필수 입력입니다.")
-        String uuid
+        int roundCount
 ) {}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/dto/CreateRoomRequest.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/dto/CreateRoomRequest.java
@@ -27,5 +27,8 @@ public record CreateRoomRequest(
         GameMode gameMode,
 
         @Min(1) @Max(5)
-        int roundCount
+        int roundCount,
+
+        @NotNull(message = "식별 번호는 필수 입력입니다.")
+        String uuid
 ) {}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/dto/EventRes.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/dto/EventRes.java
@@ -1,0 +1,10 @@
+package socket_server.domain.room.dto;
+
+import java.time.LocalDateTime;
+
+public record EventRes(
+        EventType eventType,
+        Object data,
+        LocalDateTime eventAt
+) {
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/dto/EventType.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/dto/EventType.java
@@ -1,0 +1,5 @@
+package socket_server.domain.room.dto;
+
+public enum EventType {
+    CHAT, READY, JOIN, EXIT, START
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/dto/RoomReq.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/dto/RoomReq.java
@@ -1,0 +1,12 @@
+package socket_server.domain.room.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RoomReq(
+    @NotNull
+    EventType eventType,
+    String content
+) {
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/ChatRoomHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/ChatRoomHandler.java
@@ -1,0 +1,27 @@
+package socket_server.domain.room.handler;
+
+import gotcha_domain.auth.SecurityUserDetails;
+import org.springframework.stereotype.Component;
+import socket_server.domain.room.dto.EventType;
+import socket_server.domain.room.dto.RoomReq;
+import socket_server.domain.room.service.RoomService;
+
+@Component
+public class ChatRoomHandler implements RoomEventHandler {
+
+    private final RoomService roomService;
+
+    public ChatRoomHandler(RoomService roomService) {
+        this.roomService = roomService;
+    }
+
+    @Override
+    public EventType getEventType() {
+        return EventType.CHAT;
+    }
+
+    @Override
+    public void handle(String roomId, SecurityUserDetails userDetails, RoomReq request) {
+        roomService.sendRoomChat(roomId, userDetails, request.content());
+    }
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/JoinRoomHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/JoinRoomHandler.java
@@ -1,0 +1,26 @@
+package socket_server.domain.room.handler;
+
+import gotcha_domain.auth.SecurityUserDetails;
+import org.springframework.stereotype.Component;
+import socket_server.domain.room.dto.EventType;
+import socket_server.domain.room.dto.RoomReq;
+import socket_server.domain.room.service.RoomUserService;
+
+@Component
+public class JoinRoomHandler implements RoomEventHandler{
+    private final RoomUserService roomUserService;
+
+    public JoinRoomHandler(RoomUserService roomUserService) {
+        this.roomUserService = roomUserService;
+    }
+
+    @Override
+    public EventType getEventType() {
+        return EventType.JOIN;
+    }
+
+    @Override
+    public void handle(String roomId, SecurityUserDetails userDetails, RoomReq request) {
+        roomUserService.joinAndBroadcast(roomId, userDetails.getUuid(), userDetails.getNickname());
+    }
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/JoinRoomHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/JoinRoomHandler.java
@@ -21,6 +21,6 @@ public class JoinRoomHandler implements RoomEventHandler{
 
     @Override
     public void handle(String roomId, SecurityUserDetails userDetails, RoomReq request) {
-        roomUserService.joinAndBroadcast(roomId, userDetails.getUuid(), userDetails.getNickname());
+        roomUserService.joinAndBroadcast(roomId, userDetails.getUuid(), userDetails.getNickname() ,request.content());
     }
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomEventDispatcher.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomEventDispatcher.java
@@ -1,0 +1,32 @@
+package socket_server.domain.room.handler;
+
+import gotcha_common.exception.CustomException;
+import gotcha_domain.auth.SecurityUserDetails;
+import org.springframework.stereotype.Component;
+import socket_server.common.exception.room.RoomExceptionCode;
+import socket_server.domain.room.dto.EventType;
+import socket_server.domain.room.dto.RoomReq;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class RoomEventDispatcher {
+    private final Map<EventType, RoomEventHandler> handlers;
+
+    public RoomEventDispatcher(List<RoomEventHandler> handlerList) {
+        this.handlers = handlerList.stream()
+                .collect(Collectors.toMap(RoomEventHandler::getEventType, h -> h));
+    }
+
+    public void dispatch(RoomReq request, String roomId, SecurityUserDetails userDetails) {
+        RoomEventHandler handler = handlers.get(request.eventType());
+
+        if (handler == null) {
+            throw new CustomException(RoomExceptionCode.INVALID_EVENT_TYPE);
+        }
+
+        handler.handle(roomId, userDetails, request);
+    }
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomEventHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomEventHandler.java
@@ -1,0 +1,11 @@
+package socket_server.domain.room.handler;
+
+import gotcha_domain.auth.SecurityUserDetails;
+import socket_server.domain.room.dto.EventType;
+import socket_server.domain.room.dto.RoomReq;
+
+public interface RoomEventHandler {
+    EventType getEventType();
+
+    void handle(String roomId, SecurityUserDetails userDetails, RoomReq request);
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/handler/RoomPubSubHandler.java
@@ -7,13 +7,11 @@ import org.springframework.stereotype.Service;
 import socket_server.common.config.RedisMessage;
 import socket_server.common.listener.PubSubHandler;
 import socket_server.common.util.JsonSerializer;
+import socket_server.domain.room.dto.EventRes;
 import socket_server.domain.room.model.RoomMetadata;
-import socket_server.domain.room.model.RoomUserInfo;
-
-import java.util.List;
 
 import static socket_server.common.constants.WebSocketConstants.ROOM_CREATE_INFO;
-import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
+import static socket_server.common.constants.WebSocketConstants.ROOM_EVENT;
 
 @Slf4j
 @Service
@@ -28,7 +26,7 @@ public class RoomPubSubHandler extends PubSubHandler {
     @Override
     protected void initHandlers() {
         handlers.put(ROOM_CREATE_INFO, this::roomCreateInfo);
-        handlers.put(ROOM_JOIN, this::roomJoin);
+        handlers.put(ROOM_EVENT, this::roomEvent);
     }
 
     private void roomCreateInfo(String channel, Object object) {
@@ -37,11 +35,9 @@ public class RoomPubSubHandler extends PubSubHandler {
         messagingTemplate.convertAndSend(channel, roomMetadata);
     }
 
-    private void roomJoin(String channel, Object object) {
+    private void roomEvent(String channel, Object object) {
         RedisMessage redisMessage = (RedisMessage) object;
-        // payload : List<RoomUserInfo>
-        List<RoomUserInfo> roomUserInfoList = jsonSerializer.deserializeList(redisMessage.payload(), RoomUserInfo.class);
-        messagingTemplate.convertAndSend(channel, roomUserInfoList);
+        EventRes eventRes = jsonSerializer.deserialize(redisMessage.payload(), EventRes.class);
+        messagingTemplate.convertAndSend(channel, eventRes);
     }
-
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomMetadata.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomMetadata.java
@@ -21,7 +21,7 @@ public class RoomMetadata {
     private int min;
     private String aiLevel;
     private String gameMode;
-    private String uuid;
+    private String ownerUuid;
 
 
     public static RoomMetadata fromRedisMap(String id, Map<Object, Object> map) {
@@ -35,7 +35,7 @@ public class RoomMetadata {
         metadata.min = Integer.parseInt((String) map.getOrDefault("min", "0"));
         metadata.aiLevel = (String) map.getOrDefault("aiLevel", "NORMAL");
         metadata.gameMode = (String) map.getOrDefault("gameMode", "STANDARD");
-        metadata.uuid = (String) map.getOrDefault("uuid", "");
+        metadata.ownerUuid = (String) map.getOrDefault("ownerUuid", "");
         return metadata;
     }
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomMetadata.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomMetadata.java
@@ -21,6 +21,7 @@ public class RoomMetadata {
     private int min;
     private String aiLevel;
     private String gameMode;
+    private String uuid;
 
 
     public static RoomMetadata fromRedisMap(String id, Map<Object, Object> map) {
@@ -34,6 +35,7 @@ public class RoomMetadata {
         metadata.min = Integer.parseInt((String) map.getOrDefault("min", "0"));
         metadata.aiLevel = (String) map.getOrDefault("aiLevel", "NORMAL");
         metadata.gameMode = (String) map.getOrDefault("gameMode", "STANDARD");
+        metadata.uuid = (String) map.getOrDefault("uuid", "");
         return metadata;
     }
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomUserInfo.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/model/RoomUserInfo.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class RoomUserInfo {
 
-    private String userId;
+    private String userUuid;
     private String nickname;
     private boolean ready;
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomUserRepository.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomUserRepository.java
@@ -26,8 +26,8 @@ public class RoomUserRepository {
         return "room:" + roomId + ":users";
     }
 
-    private String userRoomKey(String userId) {
-        return "user:" + userId + ":room";
+    private String userRoomKey(String userUuid) {
+        return "user:" + userUuid + ":room";
     }
 
     public void saveUserToRoom(RoomUserInfo roomUserInfo, String roomId) {
@@ -45,9 +45,9 @@ public class RoomUserRepository {
             connection.multi();
             connection.hashCommands().hSet(
                     roomUserKey(roomId).getBytes(),
-                    roomUserInfo.getUserId().getBytes(),
+                    roomUserInfo.getUserUuid().getBytes(),
                     parsedJson.getBytes());
-            connection.stringCommands().set(userRoomKey(roomUserInfo.getUserId()).getBytes(), roomId.getBytes());
+            connection.stringCommands().set(userRoomKey(roomUserInfo.getUserUuid()).getBytes(), roomId.getBytes());
             return connection.exec();
         });
     }
@@ -57,17 +57,17 @@ public class RoomUserRepository {
         return entries.values().stream().map(raw -> jsonSerializer.deserialize(raw, RoomUserInfo.class)).toList();
     }
 
-    public void removeUserFromRoom(String roomId, String userId) {
+    public void removeUserFromRoom(String roomId, String userUuid) {
         redisTemplate.execute((RedisCallback<Object>) connection -> {
             connection.multi();
-            connection.sRem(roomUserKey(roomId).getBytes(), userId.getBytes());
-            connection.sRem(userRoomKey(userId).getBytes(), roomId.getBytes());
+            connection.sRem(roomUserKey(roomId).getBytes(), userUuid.getBytes());
+            connection.sRem(userRoomKey(userUuid).getBytes(), roomId.getBytes());
             return connection.exec();
         });
     }
 
-    public String findRoomIdByUserId(String userId) {
-        return redisTemplate.opsForValue().get(userRoomKey(userId));
+    public String findRoomIdByUserUuid(String userUuid) {
+        return redisTemplate.opsForValue().get(userRoomKey(userUuid));
     }
 
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -1,6 +1,7 @@
 package socket_server.domain.room.service;
 
-import org.springframework.beans.factory.annotation.Qualifier;
+import gotcha_domain.auth.SecurityUserDetails;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import socket_server.common.config.RedisMessage;
@@ -12,27 +13,36 @@ import socket_server.domain.room.repository.RoomRepository;
 
 import java.util.Map;
 
-import static socket_server.common.constants.WebSocketConstants.PERSONAL_ROOM_CREATE_RESPONSE;
 import static socket_server.common.constants.WebSocketConstants.ROOM_CREATE_INFO;
 
 @Service
+@Slf4j
 public class RoomService {
 
     private final RoomIdService roomIdService;
+    private final RoomUserService roomUserService;
     private final JsonSerializer jsonSerializer;
     private final RoomRepository roomRepository;
     private final RedisTemplate<String, Object> objectRedisTemplate;
 
     public RoomService(
             RoomIdService roomIdService,
+            RoomUserService roomUserService,
             RoomRepository roomRepository,
             RedisTemplate<String, Object> objectRedisTemplate,
             JsonSerializer jsonSerializer
     ) {
         this.roomIdService = roomIdService;
+        this.roomUserService = roomUserService;
         this.roomRepository = roomRepository;
         this.objectRedisTemplate = objectRedisTemplate;
         this.jsonSerializer = jsonSerializer;
+    }
+
+    public void handleCreateRoom(CreateRoomRequest request, SecurityUserDetails userDetails) {
+        roomUserService.checkUserNotInAnyRoom(userDetails.getUuid());
+        RoomMetadata roomMetadata = createRoom(request, userDetails.getUuid());
+        broadcastRoomInfo(userDetails.getUuid(), roomMetadata);
     }
 
     //todo : lua 스크립트 적용
@@ -52,14 +62,14 @@ public class RoomService {
         );
 
         roomRepository.saveRoomData(roomId, roomData);
+
+        log.info("User {} created Room {}", ownerId, roomId);
         return getRoomInfo(roomId);
     }
 
     public void broadcastRoomInfo(String userId, RoomMetadata metadata) {
         objectRedisTemplate.convertAndSend(ROOM_CREATE_INFO,
                 new RedisMessage(userId, ROOM_CREATE_INFO, jsonSerializer.serialize(metadata))); //방 목록 생성 브로드 캐스트 용
-        objectRedisTemplate.convertAndSend(PERSONAL_ROOM_CREATE_RESPONSE,
-                new RedisMessage(userId, PERSONAL_ROOM_CREATE_RESPONSE, jsonSerializer.serialize(metadata))); //본인의 대기방 생성 확인 용
     }
 
     public RoomMetadata getRoomInfo(String roomId) {

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -8,9 +8,11 @@ import socket_server.common.config.RedisMessage;
 import socket_server.common.exception.room.RoomExceptionCode;
 import socket_server.common.util.JsonSerializer;
 import socket_server.domain.room.model.RoomUserInfo;
+import socket_server.domain.room.repository.RoomRepository;
 import socket_server.domain.room.repository.RoomUserRepository;
 
 import java.util.List;
+import java.util.Map;
 
 import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
 
@@ -21,20 +23,27 @@ public class RoomUserService {
     private final RedisTemplate<String, Object> objectRedisTemplate;
     private final JsonSerializer jsonSerializer;
     private final RoomUserRepository roomUserRepository;
+    private final RoomRepository roomRepository;
 
-    public RoomUserService( RedisTemplate<String, Object> objectRedisTemplate, RoomUserRepository roomUserRepository, JsonSerializer jsonSerializer) {
+    public RoomUserService( RedisTemplate<String, Object> objectRedisTemplate,
+                            RoomUserRepository roomUserRepository,
+                            JsonSerializer jsonSerializer,
+                            RoomRepository roomRepository) {
         this.jsonSerializer = jsonSerializer;
         this.roomUserRepository = roomUserRepository;
         this.objectRedisTemplate = objectRedisTemplate;
+        this.roomRepository = roomRepository;
     }
 
-    public void joinAndBroadcast(String roomId, String userUuid, String nickname) {
-        joinRoom(roomId, userUuid, nickname);
+    public void joinAndBroadcast(String roomId, String userUuid, String nickname, String password) {
+        joinRoom(roomId, userUuid, nickname, password);
         broadcastUserList(roomId, userUuid);
     }
 
-    public void joinRoom(String roomId, String userUuid, String nickname) {
+    public void joinRoom(String roomId, String userUuid, String nickname, String password) {
         checkUserNotInAnyRoom(userUuid); // after check not in any room
+
+        validatePasswordIfRequired(roomId, password);
 
         RoomUserInfo roomUserInfo = RoomUserInfo.builder().
                 userUuid(userUuid).
@@ -66,5 +75,20 @@ public class RoomUserService {
             throw new CustomException(RoomExceptionCode.USER_ALREADY_IN_ANOTHER_ROOM);
         }
     }
+
+    private void validatePasswordIfRequired(String roomId, String password) {
+        Map<Object, Object> roomData = roomRepository.getRoomData(roomId);
+        if (roomData == null || roomData.isEmpty()) {
+            throw new CustomException(RoomExceptionCode.INVALID_ROOM_ID);
+        }
+
+        if ("true".equals(roomData.get("hasPassword"))) {
+            String expectedPassword = (String) roomData.get("password");
+            if (expectedPassword == null || !expectedPassword.equals(password)) {
+                throw new CustomException(RoomExceptionCode.INCORRECT_PASSWORD);
+            }
+        }
+    }
+
 }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -1,6 +1,7 @@
 package socket_server.domain.room.service;
 
 import gotcha_common.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import socket_server.common.config.RedisMessage;
@@ -14,6 +15,7 @@ import java.util.List;
 import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
 
 @Service
+@Slf4j
 public class RoomUserService {
 
     private final RedisTemplate<String, Object> objectRedisTemplate;
@@ -26,6 +28,11 @@ public class RoomUserService {
         this.objectRedisTemplate = objectRedisTemplate;
     }
 
+    public void joinAndBroadcast(String roomId, String userUuid, String nickname) {
+        joinRoom(roomId, userUuid, nickname);
+        broadcastUserList(roomId, userUuid);
+    }
+
     public void joinRoom(String roomId, String userUuid, String nickname) {
         checkUserNotInAnyRoom(userUuid); // after check not in any room
 
@@ -36,6 +43,7 @@ public class RoomUserService {
                 build();
 
         roomUserRepository.saveUserToRoom(roomUserInfo, roomId);
+        log.info("User {} joined room {}", userUuid, roomId);
     }
 
     public void broadcastUserList(String roomId, String userId){
@@ -49,6 +57,7 @@ public class RoomUserService {
                         ROOM_JOIN+roomId,
                         jsonSerializer.serialize(userList)));
 
+        log.debug("Broadcasted user list to room {} by user {}", roomId, userId);
     }
 
     public void checkUserNotInAnyRoom(String userUuid) {

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -7,14 +7,17 @@ import org.springframework.stereotype.Service;
 import socket_server.common.config.RedisMessage;
 import socket_server.common.exception.room.RoomExceptionCode;
 import socket_server.common.util.JsonSerializer;
+import socket_server.domain.room.dto.EventRes;
+import socket_server.domain.room.dto.EventType;
 import socket_server.domain.room.model.RoomUserInfo;
 import socket_server.domain.room.repository.RoomRepository;
 import socket_server.domain.room.repository.RoomUserRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
+import static socket_server.common.constants.WebSocketConstants.ROOM_EVENT;
 
 @Service
 @Slf4j
@@ -59,12 +62,18 @@ public class RoomUserService {
         // 그 방에 누가 있는지 조회 후
         List<RoomUserInfo> userList = roomUserRepository.findUsersByRoomId(roomId);
 
+        EventRes eventRes = new EventRes(
+                EventType.JOIN,
+                userList,
+                LocalDateTime.now()
+        );
+
         // 해당 방에 누가 있는지를 BroadCast
-        objectRedisTemplate.convertAndSend(ROOM_JOIN+roomId,
+        objectRedisTemplate.convertAndSend(ROOM_EVENT+roomId,
                 new RedisMessage(
                         userId,
-                        ROOM_JOIN+roomId,
-                        jsonSerializer.serialize(userList)));
+                        ROOM_EVENT+roomId,
+                        jsonSerializer.serialize(eventRes)));
 
         log.debug("Broadcasted user list to room {} by user {}", roomId, userId);
     }
@@ -90,5 +99,8 @@ public class RoomUserService {
         }
     }
 
+    public String findRoomIdByUserUuid(String userUuid) {
+        return roomUserRepository.findRoomIdByUserUuid(userUuid);
+    }
 }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -1,6 +1,5 @@
 package socket_server.domain.room.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import gotcha_common.exception.CustomException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -10,7 +9,7 @@ import socket_server.common.util.JsonSerializer;
 import socket_server.domain.room.model.RoomUserInfo;
 import socket_server.domain.room.repository.RoomUserRepository;
 
-import java.util.*;
+import java.util.List;
 
 import static socket_server.common.constants.WebSocketConstants.ROOM_JOIN;
 
@@ -27,8 +26,15 @@ public class RoomUserService {
         this.objectRedisTemplate = objectRedisTemplate;
     }
 
-    public void joinRoom(RoomUserInfo roomUserInfo, String roomId) {
-        checkUserNotInAnyRoom(roomUserInfo.getUserId()); // after check not in any room
+    public void joinRoom(String roomId, String userUuid, String nickname) {
+        checkUserNotInAnyRoom(userUuid); // after check not in any room
+
+        RoomUserInfo roomUserInfo = RoomUserInfo.builder().
+                userUuid(userUuid).
+                nickname(nickname).
+                ready(false).
+                build();
+
         roomUserRepository.saveUserToRoom(roomUserInfo, roomId);
     }
 
@@ -45,8 +51,8 @@ public class RoomUserService {
 
     }
 
-    public void checkUserNotInAnyRoom(String userId) {
-        String value = roomUserRepository.findRoomIdByUserId(userId);
+    public void checkUserNotInAnyRoom(String userUuid) {
+        String value = roomUserRepository.findRoomIdByUserUuid(userUuid);
         if (value != null) {
             throw new CustomException(RoomExceptionCode.USER_ALREADY_IN_ANOTHER_ROOM);
         }


### PR DESCRIPTION
# 대기방 소켓 통일 및 채팅 구현

## 📝 개요  

대기방 소켓 통일 및 채팅 구현

---

## ⚙️ 구현 내용  

기존의 대기방 관련 로직들을 전체적으로 리팩토링 하였습니다.'
컨트롤러에 비즈니스 로직들이 있는 부분들을 최대한 서비스로 이동하여 역할이 분리되도록 하였습니다.


기존에는 대기방에 대한 소켓이 입장, 퇴장, 준비, 채팅 등 여러가지로 분리되어 있어.
프론트엔드와의 통합에도 불리하고, 시스템의 입장에도 과부하가 쉽게 올 수 있다고 판단되어 하나의 소켓으로 합치도록 하였습니다.

대기방을 생성할 때에는 기존과 동일하게
`/pub/room/create`를 통해 생성하지만, 생성할 때에 프론트에서 임의로 생성한 UUID를 함께 보내주어 생성자에게 두번의 전송 없이 브로드캐스팅 한번으로 생성자가 UUID를 보고 자신이 생성한 방임을 알 수 있도록 하였습니다.

대기방 내에서의 모든 이벤트는 `/pub/room/{roomId}`로 발행됩니다.
요청 dto는
```json
{
  "eventType" : "JOIN",
  "content" : "1234"
}
```
와 같이 요청됩니다. 
eventType은 해당 대기방에서 사용자가 할 이벤트(입장, 퇴장, 준비 상태 변경, 채팅) 입니다.
content는 입장시에 대기방의 비밀번호가 있다면 비밀번호, 채팅 시엔 채팅의 내용이 됩니다.

컨트롤러 내에서 dispatcher를 추가하여 요청 eventType에 따라 적절한 dispatcher가 실행되도록 하였습니다.


대기방 내에서의 모든 이벤트는 `/sub/room/event/{roomId}`로 수신됩니다.
해당 api도 /sub/room/{roomId}로 하여 발행과 통일시키려 하였으나,
/sub/room/ 을 사용하니 /sub/room/create/info로 발행되어야 하는 정보가 /sub/room/으로 가지는 오류가 있어서 /event로 하였습니다.

응답은 
```json
{
  "eventType" : "CHAT",
  "data" : {
    "nickname" : "웃긴곰",
    "content" : "시작 안해요?",
    "chatType" : "ROOM",
    "sentAt" : "2025-05-23T17:19:54.13253"
  },
  "eventAt":"2025-05-23T17:19:54.13253"
}
```
과 같이 처리됩니다.

---

## 🧪 테스트 결과  

대기방 입장 시 대기방 인원 브로드캐스팅 및 채팅 테스트
![image](https://github.com/user-attachments/assets/490b2fe5-9e61-4bcd-ab2c-893de1f8beac)


---
