### PR TITLE
feat: QnA 비밀글 조회 시 작성자 검증 로직 추가

### DIFF
--- a/gotcha-auth/src/main/java/gotcha_auth/config/SecurityConfig.java
+++ b/gotcha-auth/src/main/java/gotcha_auth/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import gotcha_domain.user.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -51,6 +52,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize ->
                         authorize
+                                .requestMatchers(HttpMethod.GET, "/api/v1/qnas/**").permitAll()
                                 .requestMatchers("/api/v1/auth/guest/sign-up").authenticated()
                                 .requestMatchers(SecurityConstants.PUBLIC_ENDPOINTS).permitAll()
                                 .requestMatchers(SecurityConstants.ADMIN_ENDPOINTS).hasAnyRole(String.valueOf(Role.ADMIN))

--- a/gotcha-auth/src/main/java/gotcha_auth/filter/JwtAuthenticationFilter.java
+++ b/gotcha-auth/src/main/java/gotcha_auth/filter/JwtAuthenticationFilter.java
@@ -40,6 +40,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         try{
+            if (accessTokenHeader == null || accessTokenHeader.isBlank()) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             Authentication auth = jwtAuthService.authenticate(accessTokenHeader);
             SecurityContextHolder.getContext().setAuthentication(auth);
 

--- a/gotcha-common/src/main/java/gotcha_common/constants/SecurityConstants.java
+++ b/gotcha-common/src/main/java/gotcha_common/constants/SecurityConstants.java
@@ -7,6 +7,11 @@ public class SecurityConstants {
             "/api/v1/notifications/**" , "/docs/**", "/ws-connect/**",  "/api/v1/ranking/**"
     };
 
+    public static final String[][] METHOD_BASED_PUBLIC_ENDPOINTS = {
+            {"GET", "/api/v1/qnas"},
+            {"GET", "/api/v1/qnas/*"},
+    };
+
     public static final String[] ADMIN_ENDPOINTS = {"/api/v1/admin/**"};
 }
 

--- a/gotcha/src/main/java/Gotcha/domain/inquiry/api/InquiryApi.java
+++ b/gotcha/src/main/java/Gotcha/domain/inquiry/api/InquiryApi.java
@@ -131,9 +131,21 @@ public interface InquiryApi {
                                     """
                             )
                     })
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "권한이 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "code": "QNA-403-001",
+                                        "status": "FORBIDDEN",
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    })
             )
     })
-    ResponseEntity<?> getInquiryById(@PathVariable(value = "inquiryId") Long inquiryId);
+    ResponseEntity<?> getInquiryById(@PathVariable(value = "inquiryId") Long inquiryId, @AuthenticationPrincipal SecurityUserDetails userDetails);
 
     @Operation(summary = "QnA 생성", description = "QnA 생성 API")
     @ApiResponses({

--- a/gotcha/src/main/java/Gotcha/domain/inquiry/controller/InquiryController.java
+++ b/gotcha/src/main/java/Gotcha/domain/inquiry/controller/InquiryController.java
@@ -61,8 +61,8 @@ public class InquiryController implements InquiryApi {
 
     @Override
     @GetMapping("/{inquiryId}")
-    public ResponseEntity<?> getInquiryById(@PathVariable(value = "inquiryId") Long inquiryId) {
-        InquiryRes inquiryRes = inquiryService.getInquiryById(inquiryId);
+    public ResponseEntity<?> getInquiryById(@PathVariable(value = "inquiryId") Long inquiryId, @AuthenticationPrincipal SecurityUserDetails userDetails) {
+        InquiryRes inquiryRes = inquiryService.getInquiryById(inquiryId, userDetails);
         return ResponseEntity.status(HttpStatus.OK).body(inquiryRes);
     }
 


### PR DESCRIPTION
# QnA 비밀글 조회 시 작성자 검증 로직 추가

## 📝 개요  

QnA 비밀글 조회 시 작성자 검증 로직 추가

---

## ⚙️ 구현 내용  

QnA 비밀글 조회 시 작성자 검증 로직을 추가하였습니다.

JwtAuthenticationFilter에서 토큰이 없을 경우 아래와 같은 로직을 추가하여
토큰이 없어도 비밀글이 아닌 QnA는 조회할 수 있도록 하였습니다.

또한, QnA의 Get메서드들은 모두 토큰 없이 조회할 수 있도록 하였습니다.

```java
if (accessTokenHeader == null || accessTokenHeader.isBlank()) {
                filterChain.doFilter(request, response);
                return;
            }
```