### PR TITLE
feat : 웹소켓 api 최신화 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,8 +3,6 @@ name: Continuous Deployment
 on:
   push:
     branches: ["develop"]
-    paths-ignore:
-      - 'gotcha-socket/src/main/resources/static/docs/**'
 
 jobs:
   deploy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,8 @@ name: Continuous Deployment
 on:
   push:
     branches: ["develop"]
+    paths-ignore:
+      - 'gotcha-socket/src/main/resources/static/docs/**'
 
 jobs:
   deploy:
@@ -22,7 +24,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      # 3. Docker 이미지 build 및 push
+        # 3. Docker 이미지 build 및 push
       - name: docker build and push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,19 +1,15 @@
 name: Update AsyncAPI Docs
 
 on:
-  push:
-    branches:
-      - develop
+  pull_request:
+    branches: [develop]
     paths:
-      - 'gotcha-socket/asyncapi.yaml'  # asyncapi.yaml 변경될 때만 실행
-
-#permissions:
-  contents: write
+      - 'gotcha-socket/asyncapi.yaml'
 
 jobs:
   generate-docs:
+    if: github.actor != 'github-actions'  # 무한 루프 방지
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Update AsyncAPI Docs
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'gotcha-socket/asyncapi.yaml'  # asyncapi.yaml 변경될 때만 실행
+
+#permissions:
+  contents: write
+
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install AsyncAPI Generator
+        run: npm install -g @asyncapi/generator
+
+      - name: Generate HTML Docs
+        run: |
+          npx @asyncapi/generator gotcha-socket/asyncapi.yaml @asyncapi/html-template -o gotcha-socket/src/main/resources/static/docs
+
+      - name: Commit and Push Generated Docs
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "actions@github.com"
+          git add gotcha-socket/src/main/resources/static/docs
+          git diff --cached --quiet || git commit -m "Auto-update AsyncAPI docs"
+          git push || echo "Nothing to push"

--- a/gotcha-socket/asyncapi.yaml
+++ b/gotcha-socket/asyncapi.yaml
@@ -1,5 +1,5 @@
 asyncapi: '2.6.0'
-id: 'urn:gotcha:websocket-api'
+id: 'gotcha:websocket-api'
 defaultContentType: application/json
 
 info:
@@ -23,15 +23,6 @@ info:
     
     [절대 경로 채널]
     - user/queue/errors : 에러 처리 채널
-  
-  
-
-  contact:
-    name: Gotcha Dev Team
-    email: gotcha@example.com
-  license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
 
 servers:
   production:
@@ -41,7 +32,27 @@ servers:
       SockJS 기반 STOMP WebSocket 연결을 지원합니다.
       기본적으로 WebSocket(ws) 사용, 실패 시 HTTP long-polling 등으로 fallback 됩니다.
 
+
+
+      핸드쉐이크 시, 반드시 HTTP 헤더에
+      Authorization: Bearer {JWT 토큰}
+      를 포함해야 합니다.
+
+
 channels:
+
+  /user/queue/errors:
+    description: |
+      사용자별 에러 메시지를 수신하는 WebSocket 구독 채널입니다.
+      서버에서 발생한 예외 정보를 이 채널로 전달합니다.
+    subscribe:
+      message:
+        name: ExceptionResponse
+        summary: 에러 응답 메시지
+        payload:
+          $ref: '#/components/schemas/ExceptionRes'
+
+
   /pub/room/create:
     description: 클라이언트가 새 방을 생성 요청하는 채널
     publish:
@@ -68,7 +79,7 @@ channels:
 
       [사용 가능한 이벤트 타입]
       - CHAT: 대기방 채팅
-      - READY: 준비 완료
+      - READY: 준비 상태 변경
       - JOIN: 방 참가
       - EXIT: 방 퇴장
       - START: 게임 시작
@@ -101,15 +112,15 @@ channels:
           - name: ChatEvent
             summary: CHAT 이벤트 - 채팅 메시지 수신
             payload:
-              $ref: '#/components/schemas/RedisResponse_Chat'
+              $ref: '#/components/schemas/RedisResponse_RoomChat'
 
           - name: JoinEvent
             summary: JOIN 이벤트 - 대기방 내 기존 유저 목록 수신
             payload:
-              $ref: '#/components/schemas/RedisResponse_Join'
+              $ref: '#/components/schemas/RedisResponse_RoomJoin'
 
           - name: ReadyEvent
-            summary: READY 이벤트 - 준비 완료 정보
+            summary: READY 이벤트 - 준비 상태 변경
 
 
           - name: ExitEvent
@@ -126,7 +137,7 @@ channels:
           type: object
           properties: {}
         payload:
-          $ref: '#/components/schemas/ChatMessageReq'
+          $ref: '#/components/schemas/RedisReq_AllChat'
 
   /sub/chat/all:
     description: 클라이언트가 전체 채팅 메시지를 수신하는 채널
@@ -135,7 +146,7 @@ channels:
         name: AllChatMessage
         summary: 전체 채팅 메시지 수신
         payload:
-          $ref: '#/components/schemas/RedisResponse_AllChat'
+          $ref: '#/components/schemas/RedisRes_AllChat'
 
   /pub/chat/private:
     description: 클라이언트가 특정 사용자에게 개인 채팅(귓속말) 메시지를 전송하는 채널입니다. `receiverUuid`에 수신 대상 사용자의 UUID를 지정하여 메시지를 전송합니다
@@ -145,7 +156,7 @@ channels:
           type: object
           properties: {}
         payload:
-          $ref: '#/components/schemas/ChatMessageReq'
+          $ref: '#/components/schemas/RedisReq_PrivateChat'
 
   /sub/chat/private/{receiverId}:
     description: 개인 채팅 메시지를 수신하는 구독 채널입니다.
@@ -159,10 +170,34 @@ channels:
         name: PrivateMessage
         summary: 개인 채팅 메시지 수신
         payload:
-          $ref: '#/components/schemas/RedisResponse_PrivateChat'
+          $ref: '#/components/schemas/RedisRes_PrivateChat'
 
 components:
   schemas:
+    ExceptionRes:
+      type: object
+      description: API 예외 응답 구조
+      properties:
+        code:
+          type: string
+          description: 에러 코드
+        status:
+          type: integer
+          format: int32
+          description: HTTP 상태 코드
+        message:
+          type: string
+          description: 에러 메시지
+        fields:
+          type: object
+          description: 필드별 상세 오류 메시지 (있을 경우)
+          additionalProperties:
+            type: string
+      required:
+        - code
+        - status
+        - message
+
     CreateRoomRequest:
       type: object
       required:
@@ -276,7 +311,7 @@ components:
             이 방을 생성한 사용자의 UUID입니다.  
             클라이언트는 해당 값을 통해 수신된 방 정보가 본인이 생성한 것인지 식별할 수 있습니다.
 
-    RedisResponse_Chat:
+    RedisResponse_RoomChat:
       type: object
       properties:
         userId:
@@ -293,9 +328,9 @@ components:
               type: string
               format: date-time
             data:
-              $ref: '#/components/schemas/ChatMessage'
+              $ref: '#/components/schemas/RoomChatMessage'
 
-    RedisResponse_Join:
+    RedisResponse_RoomJoin:
       type: object
       properties:
         userId:
@@ -316,7 +351,35 @@ components:
               items:
                 $ref: '#/components/schemas/RoomUserInfo'
 
-    ChatMessage:
+    AllChatMessage:
+      type: object
+      properties:
+        nickname:
+          type: string
+        content:
+          type: string
+        chatType:
+          type: string
+          enum: [ALL]
+        sentAt:
+          type: string
+          format: date-time
+
+    PrivateChatMessage:
+      type: object
+      properties:
+        nickname:
+          type: string
+        content:
+          type: string
+        chatType:
+          type: string
+          enum: [PRIVATE]
+        sentAt:
+          type: string
+          format: date-time
+
+    RoomChatMessage:
       type: object
       properties:
         nickname:
@@ -340,31 +403,7 @@ components:
         ready:
           type: boolean
 
-    ReadyInfo:
-      type: object
-      properties:
-        userId:
-          type: string
-        nickname:
-          type: string
-
-    ExitInfo:
-      type: object
-      properties:
-        userId:
-          type: string
-        nickname:
-          type: string
-
-    StartInfo:
-      type: object
-      properties:
-        userId:
-          type: string
-        nickname:
-          type: string
-
-    ChatMessageReq:
+    RedisReq_PrivateChat:
       type: object
       description: |
         채팅 메시지 전송 요청 객체입니다.
@@ -373,15 +412,25 @@ components:
           type: string
           nullable: true
           description: |
-            - 전체 채팅 시, `receiverUuid`가 `null`이어도 됩니다.
-            - 개인 채팅 시,  `receiverUuid'는 필수입니다.
+            - 개인 채팅 시, `receiverUuid'는 필수입니다.
         content:
           type: string
           description: 메시지 내용
       required:
         - content
 
-    RedisResponse_AllChat:
+    RedisReq_AllChat:
+      type: object
+      description: |
+        채팅 메시지 전송 요청 객체입니다.
+      properties:
+        content:
+          type: string
+          description: 메시지 내용
+      required:
+        - content
+
+    RedisRes_AllChat:
       type: object
       description: |
         - 전체 채팅 메시지를 포함하는 Redis 전송 구조
@@ -395,11 +444,9 @@ components:
           type: string
           description: Redis로 발행된 전체 채팅 채널명
         payload:
-          $ref: '#/components/schemas/ChatMessage'
+          $ref: '#/components/schemas/AllChatMessage'
 
-
-
-    RedisResponse_PrivateChat:
+    RedisRes_PrivateChat:
       type: object
       description: 특정 사용자에게 전송되는 개인 채팅 메시지 응답 구조입니다.
       properties:
@@ -410,4 +457,4 @@ components:
           type: string
           description: Redis로 발행된 개인 채팅 채널명 (`/sub/chat/private/{receiverUuid}`)
         payload:
-          $ref: '#/components/schemas/ChatMessage'
+          $ref: '#/components/schemas/PrivateChatMessage'

--- a/gotcha-socket/asyncapi.yaml
+++ b/gotcha-socket/asyncapi.yaml
@@ -8,6 +8,24 @@ info:
   description: |
     이 문서는 Gotcha 게임 플랫폼의 실시간 WebSocket(STOMP) 통신 명세서입니다.
     SockJS를 통해 WebSocket 연결을 시도합니다.
+
+    | 주체             | 동작       | 사용하는 STOMP 함수       | 경로 예시              |
+    |------------------|------------|---------------------------|-------------------------|
+    | 클라이언트 → 서버 | 메시지 보냄 | `stompClient.send()`      | `/pub/**`      |
+    | 서버 → 클라이언트 | 메시지 보냄 | `stompClient.subscribe()` | `/sub/**`         |
+
+    ⭐본 서비스에서 사용하는 채널 경로는 총 4개로 구성됩니다.
+
+    [prefix 있는 채널들]
+    - room : 대기방 관련 로직들 (대기방 내 채팅 포함)
+    - chat : 채팅 관련 로직들 (전체 채팅 및 개인 채팅)
+    - game : 게임 관련 로직들 
+    
+    [절대 경로 채널]
+    - user/queue/errors : 에러 처리 채널
+  
+  
+
   contact:
     name: Gotcha Dev Team
     email: gotcha@example.com
@@ -24,193 +42,128 @@ servers:
       기본적으로 WebSocket(ws) 사용, 실패 시 HTTP long-polling 등으로 fallback 됩니다.
 
 channels:
-  /pub/room/enter/{roomId}/:
-    description: 클라이언트가 방 입장을 요청하는 채널
-    parameters:
-      roomId:
-        description: 입장할 방의 ID
-        schema:
-          type: string
-    publish:
-      message:
-        headers:
-          type: object
-          properties:
-            user-id:
-              type: string
-              description: 요청하는 사용자의 ID
-        payload:
-          type: object
-          description: 입력 페이로드 없음
-
-
-  /pub/room/leave/{roomId}/:
-    description: 클라이언트가 방 퇴장(나감)을 요청하는 채널
-    parameters:
-      roomId:
-        description: 퇴장할 방의 ID
-        schema:
-          type: string
-    publish:
-      message:
-        headers:
-          type: object
-          properties:
-            user-id:
-              type: string
-              description: 요청하는 사용자의 ID
-        payload:
-          type: object
-          description: 입력 페이로드 없음
-
   /pub/room/create/:
     description: 클라이언트가 새 방을 생성 요청하는 채널
     publish:
       message:
         headers:
           type: object
-          properties:
-            user-id:
-              type: string
-              description: 요청하는 사용자의 ID
+          properties: {}
         payload:
           $ref: '#/components/schemas/CreateRoomRequest'
 
-  /pub/room/update/:
-    description: 클라이언트가 방 속성을 수정 요청하는 채널
+  /sub/room/create/info:
+    description: 클라이언트가 방 생성 응답을 받는 용도
+    subscribe:
+      message:
+        headers:
+          type: object
+          properties: {}
+        payload:
+          $ref: '#/components/schemas/RedisResponse'
+
+  /pub/chat/all/:
+    description: 클라이언트가 새 방을 생성 요청하는 채널
     publish:
       message:
         headers:
           type: object
-          properties:
-            user-id:
-              type: string
-              description: 요청하는 사용자의 ID
+          properties: {}
         payload:
-          $ref: '#/components/schemas/UpdateRoomFieldRequest'
+          $ref: '#/components/schemas/CreateRoomRequest'
 
-  /sub/room/init/info/{roomId}/:
-    description: 서버가 방 초기 정보(메타 + 참가자 목록) 브로드캐스트
-    parameters:
-      roomId:
-        description: 해당 방의 ID
-        schema:
-          type: string
-    subscribe:
-      message:
-        payload:
-          type: object
-          properties:
-            roomId:
-              type: string
-            title:
-              type: string
-            owner:
-              type: string
-            hasPassword:
-              type: boolean
-            password:
-              type: string
-            max:
-              type: integer
-            min:
-              type: integer
-            aiLevel:
-              type: string
-            gameMode:
-              type: string
-            users:
-              type: array
-              items:
-                type: string
-            joinedUserId:
-              type: string
-
-  /sub/room/leave/{roomId}:
-    description: 서버가 방 퇴장 알림 브로드캐스트
-    parameters:
-      roomId:
-        description: 해당 방의 ID
-        schema:
-          type: string
-    subscribe:
-      message:
-        payload:
-          type: object
-          properties:
-            userId:
-              type: string
-
-  /sub/room/create:
-    description: 서버가 새 방 생성 알림 브로드캐스트
-    subscribe:
-      message:
-        payload:
-          $ref: '#/components/schemas/RoomMetadata'
-
-  /sub/room/update/{roomId}:
-    description: 서버가 방 정보 변경 알림 브로드캐스트
-    parameters:
-      roomId:
-        description: 해당 방의 ID
-        schema:
-          type: string
-    subscribe:
-      message:
-        payload:
-          $ref: '#/components/schemas/RoomMetadata'
 
 components:
   schemas:
     CreateRoomRequest:
       type: object
+      required:
+        - title
+        - maxUser
+        - hasPassword
+        - aimode
+        - gameMode
+        - roundCount
       properties:
-        roomId:
-          type: string
         title:
           type: string
+          description: 제목 (필수 입력)
+
+        maxUser:
+          type: integer
+          description: 최대 인원수 (필수 입력)
+
         hasPassword:
           type: boolean
+          description: 비밀번호 사용 여부
+
         password:
           type: string
-        gameMode:
-          type: object
-          properties:
-            name:
-              type: string
-            maxPlayers:
-              type: integer
-            minPlayers:
-              type: integer
+          description: 문자열이 숫자 4자리로만 구성되어 있어야 한다
 
-    UpdateRoomFieldRequest:
+        aimode:
+          type: string
+          enum: [BASIC, ADVANCED]
+          description: 인공지능 난이도 (필수)
+
+        gameMode:
+          type: string
+          enum: [TRICK_MYOMYO, LULU_ART_EXAM]
+          description: 묘묘 - 2인 / 루루 - 1인 게임 모드
+
+        roundCount:
+          type: integer
+          minimum: 1
+          maximum: 5
+          description: 라운드 수 (1~5 사이)
+
+    RedisResponse:
       type: object
       properties:
-        roomId:
+        userId:
           type: string
-        field:
+          description: 사용자 고유 UUID
+        topic:
           type: string
-          description: 변경할 필드명 (e.g. \"OWNER\", \"TITLE\" 등)
-        value:
-          type: string
-          description: 변경할 값
+          description: Redis로 발행된 채널명
+        payload:
+          $ref: '#/components/schemas/RoomMetadata'
 
     RoomMetadata:
       type: object
       properties:
+        id:
+          type: string
+          description: 방 ID
         title:
           type: string
+          description: 방 제목
         owner:
           type: string
+          description: 방장 닉네임
         hasPassword:
           type: boolean
+          description: 비밀번호 사용 여부
         password:
           type: string
+          description: 비밀번호 (빈 문자열일 수 있음)
         max:
           type: integer
+          description: 최대 인원 수
         min:
           type: integer
+          description: 최소 인원 수
         aiLevel:
           type: string
+          enum: [BASIC, ADVANCED]
+          description: AI 난이도
         gameMode:
           type: string
+          enum: [TRICK_MYOMYO, LULU_ART_EXAM]
+          description: 게임 모드
+        ownerUuid:
+          type: string
+          description: |
+            이 방을 생성한 사용자의 UUID입니다.  
+            클라이언트는 해당 값을 통해 수신된 방 정보가 본인이 생성한 것인지 식별할 수 있습니다.
+

--- a/gotcha-socket/asyncapi.yaml
+++ b/gotcha-socket/asyncapi.yaml
@@ -14,12 +14,12 @@ info:
     | 클라이언트 → 서버 | 메시지 보냄 | `stompClient.send()`      | `/pub/**`      |
     | 서버 → 클라이언트 | 메시지 보냄 | `stompClient.subscribe()` | `/sub/**`         |
 
-    ⭐본 서비스에서 사용하는 채널 경로는 총 4개로 구성됩니다.
+    ⭐본 서비스에서 사용하는 메시지 전송 경로는 총 4개로 구성됩니다. 로직에 따른 구독 경로를 달리하지 않고, dto로 로직을 구분합니다.
 
     [prefix 있는 채널들]
-    - room : 대기방 관련 로직들 (대기방 내 채팅 포함)
-    - chat : 채팅 관련 로직들 (전체 채팅 및 개인 채팅)
-    - game : 게임 관련 로직들 
+    - /pub/room/{roomId} : 대기방 관련 로직들 (대기방 내 채팅 포함)
+    - /pub/chat/** : 채팅 관련 로직들 (전체 채팅 및 개인 채팅)
+    - /pub/game/** : 게임 관련 로직들 
     
     [절대 경로 채널]
     - user/queue/errors : 에러 처리 채널
@@ -42,7 +42,7 @@ servers:
       기본적으로 WebSocket(ws) 사용, 실패 시 HTTP long-polling 등으로 fallback 됩니다.
 
 channels:
-  /pub/room/create/:
+  /pub/room/create:
     description: 클라이언트가 새 방을 생성 요청하는 채널
     publish:
       message:
@@ -60,9 +60,65 @@ channels:
           type: object
           properties: {}
         payload:
-          $ref: '#/components/schemas/RedisResponse'
+          $ref: '#/components/schemas/RedisResponse_RoomMetadata'
 
-  /pub/chat/all/:
+  /pub/room/{roomId}:
+    description: |
+      클라이언트가 대기방 내에서 발생 가능한 로직 요청을 전송하는 채널입니다.
+
+      [사용 가능한 이벤트 타입]
+      - CHAT: 대기방 채팅
+      - READY: 준비 완료
+      - JOIN: 방 참가
+      - EXIT: 방 퇴장
+      - START: 게임 시작
+
+      `eventType` 값에 따라 content의 의미는 다르게 해석됩니다.
+    parameters:
+      roomId:
+        description: 대상 대기방의 고유 ID
+        schema:
+          type: string
+    publish:
+      message:
+        name: RoomEventRequest
+        summary: 대기방 내 요청 이벤트 전송
+        contentType: application/json
+        payload:
+          $ref: '#/components/schemas/RoomReq'
+
+  /sub/room/event/{roomId}:
+    description: |
+      클라이언트가 대기방 내에서 발생 가능한 로직 처리 결과를 응답 받는 채널입니다.
+    parameters:
+      roomId:
+        description: 대기방 고유 ID
+        schema:
+          type: string
+    subscribe:
+      message:
+        oneOf:
+          - name: ChatEvent
+            summary: CHAT 이벤트 - 채팅 메시지 수신
+            payload:
+              $ref: '#/components/schemas/RedisResponse_Chat'
+
+          - name: JoinEvent
+            summary: JOIN 이벤트 - 입장 유저 목록 수신
+            payload:
+              $ref: '#/components/schemas/RedisResponse_Join'
+
+          - name: ReadyEvent
+            summary: READY 이벤트 - 준비 완료 정보
+
+
+          - name: ExitEvent
+            summary: EXIT 이벤트 - 퇴장 정보
+
+          - name: StartEvent
+            summary: START 이벤트 - 게임 시작 알림
+
+  /pub/chat/all:
     description: 클라이언트가 새 방을 생성 요청하는 채널
     publish:
       message:
@@ -70,8 +126,35 @@ channels:
           type: object
           properties: {}
         payload:
-          $ref: '#/components/schemas/CreateRoomRequest'
+          $ref: '#/components/schemas/ChatMessageReq'
 
+  /sub/chat/all:
+    description: 전체 채팅 메시지를 수신하는 구독 채널입니다.
+    subscribe:
+      message:
+        name: AllChatMessage
+        summary: 전체 채팅 메시지 수신
+        payload:
+          $ref: '#/components/schemas/RedisResponse_AllChat'
+
+  /pub/chat/private:
+    description: 클라이언트가 특정 사용자에게 개인 채팅(귓속말) 메시지를 전송하는 채널입니다. `receiverUuid`에 수신 대상 사용자의 UUID를 지정하여 메시지를 전송합니다
+    publish:
+      message:
+        headers:
+          type: object
+          properties: {}
+        payload:
+          $ref: '#/components/schemas/ChatMessageReq'
+
+  /sub/chat/private/{receiverId}:
+    description: 개인 채팅 메시지를 수신하는 구독 채널입니다.
+    subscribe:
+      message:
+        name: PrivateMessage
+        summary: 개인 채팅 메시지 수신
+        payload:
+          $ref: '#/components/schemas/RedisResponse_PrivateChat'
 
 components:
   schemas:
@@ -117,12 +200,33 @@ components:
           maximum: 5
           description: 라운드 수 (1~5 사이)
 
-    RedisResponse:
+    RoomReq:
       type: object
+      required:
+        - eventType
+      properties:
+        eventType:
+          type: string
+          enum: [CHAT, READY, JOIN, EXIT, START]
+          description: |
+            클라이언트가 수행하고자 하는 이벤트의 종류입니다.
+        content:
+          type: string
+          description: |
+            이벤트에 따라 의미가 달라지는 콘텐츠입니다.
+            - CHAT: 채팅 메시지
+            - READY: 사용자의 준비 상태
+            - JOIN : 방 참가
+            - EXIT : 방 퇴장
+            - START : 게임 시작
+
+    RedisResponse_RoomMetadata:
+      type: object
+      description: 방 생성/요청 응답용 Redis 메시지 (RoomMetadata 포함)
       properties:
         userId:
           type: string
-          description: 사용자 고유 UUID
+          description: 메시지를 보낸 사용자 UUID
         topic:
           type: string
           description: Redis로 발행된 채널명
@@ -167,3 +271,137 @@ components:
             이 방을 생성한 사용자의 UUID입니다.  
             클라이언트는 해당 값을 통해 수신된 방 정보가 본인이 생성한 것인지 식별할 수 있습니다.
 
+    RedisResponse_Chat:
+      type: object
+      properties:
+        userId:
+          type: string
+        topic:
+          type: string
+        payload:
+          type: object
+          properties:
+            eventType:
+              type: string
+              enum: [CHAT]
+            eventAt:
+              type: string
+              format: date-time
+            data:
+              $ref: '#/components/schemas/ChatMessage'
+
+    RedisResponse_Join:
+      type: object
+      properties:
+        userId:
+          type: string
+        topic:
+          type: string
+        payload:
+          type: object
+          properties:
+            eventType:
+              type: string
+              enum: [JOIN]
+            eventAt:
+              type: string
+              format: date-time
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/RoomUserInfo'
+
+    ChatMessage:
+      type: object
+      properties:
+        nickname:
+          type: string
+        content:
+          type: string
+        chatType:
+          type: string
+          enum: [ROOM]
+        sentAt:
+          type: string
+          format: date-time
+
+    RoomUserInfo:
+      type: object
+      properties:
+        userId:
+          type: string
+        nickname:
+          type: string
+
+    ReadyInfo:
+      type: object
+      properties:
+        userId:
+          type: string
+        nickname:
+          type: string
+
+    ExitInfo:
+      type: object
+      properties:
+        userId:
+          type: string
+        nickname:
+          type: string
+
+    StartInfo:
+      type: object
+      properties:
+        userId:
+          type: string
+        nickname:
+          type: string
+
+    ChatMessageReq:
+      type: object
+      description: |
+        채팅 메시지 전송 요청 객체입니다.
+
+        - `receiverUuid`가 `null`이면 전체 채팅으로 간주됩니다.
+        - 특정 사용자의 UUID를 설정하면 1:1 개인 채팅으로 전송됩니다.
+      properties:
+        receiverUuid:
+          type: string
+          nullable: true
+          description: |
+            수신 대상 사용자의 UUID입니다.  
+            null이면 전체 채팅, UUID가 지정되면 개인 채팅으로 처리됩니다.
+        content:
+          type: string
+          description: 메시지 내용
+      required:
+        - content
+
+    RedisResponse_AllChat:
+      type: object
+      description: 전체 채팅 메시지를 포함하는 Redis 전송 구조
+      properties:
+        userId:
+          type: string
+          nullable: true
+          description: null (전체 채팅이므로 사용자 구분 없음)
+        topic:
+          type: string
+          description: Redis로 발행된 전체 채팅 채널명
+        payload:
+          $ref: '#/components/schemas/ChatMessage'
+
+
+
+    RedisResponse_PrivateChat:
+      type: object
+      description: 특정 사용자에게 전송되는 개인 채팅 메시지 응답 구조입니다.
+      properties:
+        userId:
+          type: string
+          description: 수신 대상 사용자의 UUID입니다.
+        topic:
+          type: string
+          description: Redis로 발행된 개인 채팅 채널명 (`/sub/chat/private/{receiverUuid}`)
+        payload:
+          $ref: '#/components/schemas/ChatMessage'

--- a/gotcha-socket/asyncapi.yaml
+++ b/gotcha-socket/asyncapi.yaml
@@ -104,7 +104,7 @@ channels:
               $ref: '#/components/schemas/RedisResponse_Chat'
 
           - name: JoinEvent
-            summary: JOIN 이벤트 - 입장 유저 목록 수신
+            summary: JOIN 이벤트 - 대기방 내 기존 유저 목록 수신
             payload:
               $ref: '#/components/schemas/RedisResponse_Join'
 
@@ -119,7 +119,7 @@ channels:
             summary: START 이벤트 - 게임 시작 알림
 
   /pub/chat/all:
-    description: 클라이언트가 새 방을 생성 요청하는 채널
+    description: 클라이언트가 전체 채팅 메시지를 전송하는 채널
     publish:
       message:
         headers:
@@ -129,7 +129,7 @@ channels:
           $ref: '#/components/schemas/ChatMessageReq'
 
   /sub/chat/all:
-    description: 전체 채팅 메시지를 수신하는 구독 채널입니다.
+    description: 클라이언트가 전체 채팅 메시지를 수신하는 채널
     subscribe:
       message:
         name: AllChatMessage
@@ -328,10 +328,12 @@ components:
     RoomUserInfo:
       type: object
       properties:
-        userId:
+        userUuid:
           type: string
         nickname:
           type: string
+        ready:
+          type: boolean
 
     ReadyInfo:
       type: object
@@ -361,16 +363,13 @@ components:
       type: object
       description: |
         채팅 메시지 전송 요청 객체입니다.
-
-        - `receiverUuid`가 `null`이면 전체 채팅으로 간주됩니다.
-        - 특정 사용자의 UUID를 설정하면 1:1 개인 채팅으로 전송됩니다.
       properties:
         receiverUuid:
           type: string
           nullable: true
           description: |
-            수신 대상 사용자의 UUID입니다.  
-            null이면 전체 채팅, UUID가 지정되면 개인 채팅으로 처리됩니다.
+            - 전체 채팅 시, `receiverUuid`가 `null`이어도 됩니다.
+            - 개인 채팅 시,  `receiverUuid'는 필수입니다.
         content:
           type: string
           description: 메시지 내용
@@ -379,7 +378,9 @@ components:
 
     RedisResponse_AllChat:
       type: object
-      description: 전체 채팅 메시지를 포함하는 Redis 전송 구조
+      description: |
+        - 전체 채팅 메시지를 포함하는 Redis 전송 구조
+        - 응답 시 ChatType은 ALL, ROOM, PRIVATE중 하나로 전송됩니다.
       properties:
         userId:
           type: string

--- a/gotcha-socket/asyncapi.yaml
+++ b/gotcha-socket/asyncapi.yaml
@@ -149,6 +149,11 @@ channels:
 
   /sub/chat/private/{receiverId}:
     description: 개인 채팅 메시지를 수신하는 구독 채널입니다.
+    parameters:
+      receiverId:
+        description: ID of the message receiver
+        schema:
+          type: string
     subscribe:
       message:
         name: PrivateMessage

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -116,9 +116,9 @@ public class RoomService {
         log.info("chat - roomId: {}, user: {}, content: {}", roomId, userDetails.getUuid(), content);
     }
 
-    public void broadcastRoomInfo(String userId, RoomMetadata metadata) {
+    public void broadcastRoomInfo(String userUuid, RoomMetadata metadata) {
         objectRedisTemplate.convertAndSend(ROOM_CREATE_INFO,
-                new RedisMessage(userId, ROOM_CREATE_INFO, jsonSerializer.serialize(metadata))); //방 목록 생성 브로드 캐스트 용
+                new RedisMessage(userUuid, ROOM_CREATE_INFO, jsonSerializer.serialize(metadata))); //방 목록 생성 브로드 캐스트 용
     }
 
     public RoomMetadata getRoomInfo(String roomId) {


### PR DESCRIPTION
# 웹소켓 api 최신화 

## 📝 개요  

지금까지 작성된 웹소켓 api 들 최신화 작업입니다.
---

## ⚙️ 구현 내용  

1. 방 생성 / 대기방 채팅 / 대기방 참가 / 전체 채팅 / 비밀 채팅 웹소켓 로직에 대한 전송 채널 및 수신 채널 API 최신화

2. GitHub 워크플로우 수정
   - asyncapi.yaml 문서가 수정되었을 때, 최신 HTML 문서로 regenerate하여 PR을 생성하고 배포에 포함될 수 있도록 하는 워크플로우(docs.yml) 추가
   - cd.yml은 develop 브랜치에 변경이 머지되었을 때 실행되며, regenerate된 문서(정적 HTML 파일 포함)를 함께 Docker 이미지에 패키징하여 배포하는 역할을 수행


---

