### PR TITLE
feat: 자기 랭킹 조회 기능 구현

### DIFF
--- a/gotcha-common/src/main/java/gotcha_common/constants/SecurityConstants.java
+++ b/gotcha-common/src/main/java/gotcha_common/constants/SecurityConstants.java
@@ -4,7 +4,7 @@ public class SecurityConstants {
     public static final String[] PUBLIC_ENDPOINTS = {
             "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
             "/webjars/**", "/error", "/api/v1/auth/**", "/api/v1/users/nickname-check",
-            "/api/v1/notifications/**" , "/docs/**", "/ws-connect/**",  "/api/v1/ranking/**"
+            "/api/v1/notifications/**" , "/docs/**", "/ws-connect/**",  "/api/v1/ranking"
     };
 
     public static final String[][] METHOD_BASED_PUBLIC_ENDPOINTS = {

--- a/gotcha/src/main/java/Gotcha/domain/ranking/api/RankingApi.java
+++ b/gotcha/src/main/java/Gotcha/domain/ranking/api/RankingApi.java
@@ -1,0 +1,91 @@
+package Gotcha.domain.ranking.api;
+
+import gotcha_domain.auth.SecurityUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "[랭킹 API]", description = "랭킹 관련 API")
+public interface RankingApi {
+
+    @Operation(summary = "전체 랭킹 조회", description = "전체 랭킹 페이지 별 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "전체 랭킹 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    [
+                                        {
+                                            "rank": 1,
+                                            "nickname": "관리자",
+                                            "exp": 2222,
+                                            "level": 11
+                                        },
+                                        {
+                                            "rank": 2,
+                                            "nickname": "테스트",
+                                            "exp": 992,
+                                            "level": 7
+                                        },
+                                        {
+                                            "rank": 3,
+                                            "nickname": "테스터다",
+                                            "exp": 722,
+                                            "level": 6
+                                        },
+                                        {
+                                            "rank": 4,
+                                            "nickname": "김승제",
+                                            "exp": 0,
+                                            "level": 1
+                                        },
+                                        {
+                                            "rank": 5,
+                                            "nickname": "김승제임",
+                                            "exp": 0,
+                                            "level": 1
+                                        },
+                                        {
+                                            "rank": 6,
+                                            "nickname": "dryice",
+                                            "exp": 0,
+                                            "level": 1
+                                        }
+                                    ]
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getUserRankingPage(@RequestParam(defaultValue = "0") int page);
+
+
+    @Operation(summary = "자기 랭킹 조회", description = "자기 자신의 랭킹 및 전체 경험치 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "자기 랭킹 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "rank": 2,
+                                        "nickname": "테스트",
+                                        "exp": 992,
+                                        "level": 7
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "랭킹에 등록되지 않은 사용자",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "code": "RANK-404-001",
+                                        "status": "NOT_FOUND",
+                                        "message": "랭킹에 등록되지 않은 사용자입니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getMyRanking(@AuthenticationPrincipal SecurityUserDetails userDetails);
+}

--- a/gotcha/src/main/java/Gotcha/domain/ranking/controller/RankingController.java
+++ b/gotcha/src/main/java/Gotcha/domain/ranking/controller/RankingController.java
@@ -1,8 +1,10 @@
 package Gotcha.domain.ranking.controller;
 
 import Gotcha.domain.ranking.service.RankingRedisService;
+import gotcha_domain.auth.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,5 +19,10 @@ public class RankingController {
     @GetMapping()
     public ResponseEntity<?> getUserRankingPage(@RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(rankingRedisService.getUserRankingPage(page));
+    }
+
+    @GetMapping("/mine")
+    public ResponseEntity<?> getMyRanking(@AuthenticationPrincipal SecurityUserDetails userDetails) {
+        return ResponseEntity.ok(rankingRedisService.getUserRank(userDetails.getId()));
     }
 }

--- a/gotcha/src/main/java/Gotcha/domain/ranking/controller/RankingController.java
+++ b/gotcha/src/main/java/Gotcha/domain/ranking/controller/RankingController.java
@@ -1,7 +1,9 @@
 package Gotcha.domain.ranking.controller;
 
+import Gotcha.domain.ranking.api.RankingApi;
 import Gotcha.domain.ranking.service.RankingRedisService;
 import gotcha_domain.auth.SecurityUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,14 +15,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/ranking")
-public class RankingController {
+public class RankingController implements RankingApi {
     private final RankingRedisService rankingRedisService;
 
+    @Operation
     @GetMapping()
     public ResponseEntity<?> getUserRankingPage(@RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(rankingRedisService.getUserRankingPage(page));
     }
 
+    @Override
     @GetMapping("/mine")
     public ResponseEntity<?> getMyRanking(@AuthenticationPrincipal SecurityUserDetails userDetails) {
         return ResponseEntity.ok(rankingRedisService.getUserRank(userDetails.getId()));

--- a/gotcha/src/main/java/Gotcha/domain/ranking/controller/RankingController.java
+++ b/gotcha/src/main/java/Gotcha/domain/ranking/controller/RankingController.java
@@ -3,7 +3,6 @@ package Gotcha.domain.ranking.controller;
 import Gotcha.domain.ranking.api.RankingApi;
 import Gotcha.domain.ranking.service.RankingRedisService;
 import gotcha_domain.auth.SecurityUserDetails;
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RankingController implements RankingApi {
     private final RankingRedisService rankingRedisService;
 
-    @Operation
+    @Override
     @GetMapping()
     public ResponseEntity<?> getUserRankingPage(@RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(rankingRedisService.getUserRankingPage(page));

--- a/gotcha/src/main/java/Gotcha/domain/ranking/exception/RankingExceptionCode.java
+++ b/gotcha/src/main/java/Gotcha/domain/ranking/exception/RankingExceptionCode.java
@@ -1,0 +1,29 @@
+package Gotcha.domain.ranking.exception;
+
+import gotcha_common.exception.exceptionCode.ExceptionCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum RankingExceptionCode implements ExceptionCode {
+    RANKING_NOT_FOUND(HttpStatus.NOT_FOUND, "RANK-404-001", "랭킹에 등록되지 않은 사용자입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/gotcha/src/main/java/Gotcha/domain/ranking/service/RankingRedisService.java
+++ b/gotcha/src/main/java/Gotcha/domain/ranking/service/RankingRedisService.java
@@ -79,7 +79,7 @@ public class RankingRedisService {
 
     //사용자 랭킹 조회
     public RankingUserRes getUserRank(Long userId) {
-        Long rank = stringRedisTemplate.opsForZSet().reverseRank(RANKING_KEY_PREFIX, userId.toString()) + 1;
+        Long rank = stringRedisTemplate.opsForZSet().reverseRank(RANKING_KEY_PREFIX, userId.toString());
 
         User user = userService.findUserByUserId(userId);
 
@@ -87,7 +87,7 @@ public class RankingRedisService {
             throw new CustomException(RankingExceptionCode.RANKING_NOT_FOUND);
         }
 
-        return RankingUserRes.of(user, rank);
+        return RankingUserRes.of(user, rank + 1);
     }
 
     //사용자 경험치 조회

--- a/gotcha/src/main/java/Gotcha/domain/ranking/service/RankingRedisService.java
+++ b/gotcha/src/main/java/Gotcha/domain/ranking/service/RankingRedisService.java
@@ -1,8 +1,11 @@
 package Gotcha.domain.ranking.service;
 
 import Gotcha.domain.ranking.dto.RankingUserRes;
+import Gotcha.domain.ranking.exception.RankingExceptionCode;
+import gotcha_common.exception.CustomException;
 import gotcha_domain.user.User;
 import gotcha_user.repository.UserRepository;
+import gotcha_user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -22,6 +25,7 @@ import static gotcha_common.redis.RedisProperties.RANKING_KEY_PREFIX;
 public class RankingRedisService {
     private final StringRedisTemplate stringRedisTemplate;
     private final UserRepository userRepository;
+    private final UserService userService;
 
     private static final int SIZE = 20;
 
@@ -74,8 +78,16 @@ public class RankingRedisService {
     }
 
     //사용자 랭킹 조회
-    public Long getUserRank(Long userId) {
-        return stringRedisTemplate.opsForZSet().reverseRank(RANKING_KEY_PREFIX, userId.toString());
+    public RankingUserRes getUserRank(Long userId) {
+        Long rank = stringRedisTemplate.opsForZSet().reverseRank(RANKING_KEY_PREFIX, userId.toString()) + 1;
+
+        User user = userService.findUserByUserId(userId);
+
+        if (rank == null) {
+            throw new CustomException(RankingExceptionCode.RANKING_NOT_FOUND);
+        }
+
+        return RankingUserRes.of(user, rank);
     }
 
     //사용자 경험치 조회


### PR DESCRIPTION
# 자기 랭킹 조회 기능 구현

## 📝 개요  

자기 랭킹 조회 기능 구현

---

## ⚙️ 구현 내용  

기존의 전체 랭킹 조회와 비슷한 방식으로 자기 자신의 랭킹과 정보를 조회할 수 있는 로직을 작성하였습니다.

사용자는 자신이 랭킹에 등록되어있는 경우, 자신의 랭킹, 닉네임, 전체 경험치량, 레벨을 응답으로 받게 됩니다.

---
## 🧪 테스트 결과  

<img width="577" alt="image" src="https://github.com/user-attachments/assets/0f212070-b413-4e01-b129-e2b9eb7fed56" />

---
