### PR TITLE
feat: S3 이미지 업로드 기능 구현

### DIFF
--- a/gotcha-common/build.gradle
+++ b/gotcha-common/build.gradle
@@ -1,3 +1,8 @@
+ext{
+    springCloudAwsVersion = '3.3.0'
+}
+
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
@@ -6,6 +11,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'jakarta.mail:jakarta.mail-api:2.1.2'
+
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:${springCloudAwsVersion}")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/gotcha-common/src/main/java/gotcha_common/exception/exceptionCode/GlobalExceptionCode.java
+++ b/gotcha-common/src/main/java/gotcha_common/exception/exceptionCode/GlobalExceptionCode.java
@@ -11,7 +11,8 @@ public enum GlobalExceptionCode implements ExceptionCode {
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-401-001", "인증된 사용자를 찾을 수 없습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH-403-001", "접근 권한이 없습니다."),
     INVALID_MESSAGE_FORMAT(HttpStatus.BAD_REQUEST, "GLOBAL_400_002", "유효하지 않은 메시지 포맷 입니다."),
-    INVALID_CHANNEL(HttpStatus.BAD_REQUEST, "GLOBAL_400_003", "유효하지 않은 소켓 채널입니다.");
+    INVALID_CHANNEL(HttpStatus.BAD_REQUEST, "GLOBAL_400_003", "유효하지 않은 소켓 채널입니다."),
+    INVALID_IMAGE(HttpStatus.BAD_REQUEST, "GLOBAL_400_004", "유효하지 않은 이미지 파일입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha-common/src/main/java/gotcha_common/exception/exceptionCode/GlobalExceptionCode.java
+++ b/gotcha-common/src/main/java/gotcha_common/exception/exceptionCode/GlobalExceptionCode.java
@@ -12,7 +12,7 @@ public enum GlobalExceptionCode implements ExceptionCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH-403-001", "접근 권한이 없습니다."),
     INVALID_MESSAGE_FORMAT(HttpStatus.BAD_REQUEST, "GLOBAL_400_002", "유효하지 않은 메시지 포맷 입니다."),
     INVALID_CHANNEL(HttpStatus.BAD_REQUEST, "GLOBAL_400_003", "유효하지 않은 소켓 채널입니다."),
-    INVALID_IMAGE(HttpStatus.BAD_REQUEST, "GLOBAL_400_004", "유효하지 않은 이미지 파일입니다.");
+    FILE_PROCESS_ERROR(HttpStatus.BAD_REQUEST, "GLOBAL_400_004", "파일 처리 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha-common/src/main/java/gotcha_common/s3/S3ClientService.java
+++ b/gotcha-common/src/main/java/gotcha_common/s3/S3ClientService.java
@@ -1,0 +1,39 @@
+
+
+package gotcha_common.s3;
+
+
+import gotcha_common.exception.CustomException;
+import gotcha_common.exception.exceptionCode.GlobalExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+
+@Service
+@RequiredArgsConstructor
+public class S3ClientService {
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket-name}")
+    private String bucketName;
+
+    // MultipartFile 이미지를 그대로 S3에 업로드
+    public void uploadImage(String filename, MultipartFile file){
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(filename)
+                    .contentType(file.getContentType())
+                    .build();
+            s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch(Exception e){
+            throw new CustomException(GlobalExceptionCode.INVALID_IMAGE);
+        }
+    }
+
+}

--- a/gotcha-common/src/main/java/gotcha_common/s3/S3ClientService.java
+++ b/gotcha-common/src/main/java/gotcha_common/s3/S3ClientService.java
@@ -12,6 +12,9 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
 
 
 @Service
@@ -23,7 +26,7 @@ public class S3ClientService {
     private String bucketName;
 
     // MultipartFile 이미지를 그대로 S3에 업로드
-    public void uploadImage(String filename, MultipartFile file){
+    public void uploadFile(String filename, MultipartFile file){
         try {
             PutObjectRequest request = PutObjectRequest.builder()
                     .bucket(bucketName)
@@ -31,8 +34,8 @@ public class S3ClientService {
                     .contentType(file.getContentType())
                     .build();
             s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
-        } catch(Exception e){
-            throw new CustomException(GlobalExceptionCode.INVALID_IMAGE);
+        } catch(IOException e){
+            throw new CustomException(GlobalExceptionCode.FILE_PROCESS_ERROR);
         }
     }
 

--- a/gotcha-common/src/main/resources/application.properties
+++ b/gotcha-common/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=gotcha-common

--- a/gotcha-common/src/main/resources/application.yml
+++ b/gotcha-common/src/main/resources/application.yml
@@ -2,14 +2,5 @@ spring:
   application:
     name: gotcha-common
 
-  cloud:
-    aws:
-      credentials:
-        access-key: ${AWS_S3_ACCESS_KEY}
-        secret-key: ${AWS_S3_SECRET_KEY}
-      s3:
-        bucket-name: ${AWS_S3_BUCKET_NAME}
 
-      region:
-        static: ${AWS_S3_REGION}
 

--- a/gotcha-common/src/main/resources/application.yml
+++ b/gotcha-common/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: gotcha-common
+
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_S3_ACCESS_KEY}
+        secret-key: ${AWS_S3_SECRET_KEY}
+      s3:
+        bucket-name: ${AWS_S3_BUCKET_NAME}
+
+      region:
+        static: ${AWS_S3_REGION}
+

--- a/gotcha/src/main/java/Gotcha/domain/image/api/ImageApi.java
+++ b/gotcha/src/main/java/Gotcha/domain/image/api/ImageApi.java
@@ -1,0 +1,13 @@
+package Gotcha.domain.image.api;
+
+
+import gotcha_domain.auth.SecurityUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageApi {
+    @PostMapping("/upload")
+    ResponseEntity<?> uploadImage(@RequestParam("file") MultipartFile file, SecurityUserDetails userDetails);
+}

--- a/gotcha/src/main/java/Gotcha/domain/image/api/ImageApi.java
+++ b/gotcha/src/main/java/Gotcha/domain/image/api/ImageApi.java
@@ -2,12 +2,44 @@ package Gotcha.domain.image.api;
 
 
 import gotcha_domain.auth.SecurityUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "[이미지 업로드 API]", description = "이미지 업로드 API")
 public interface ImageApi {
-    @PostMapping("/upload")
+
+    @Operation(summary = "이미지 업로드", description = "이미지 업로드 API, png, jpg, jpeg 파일만 허용합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 업로드 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": "OK",
+                                        "message": "https://my-bucket-name.s3.ap-northeast-2.amazonaws.com/1234/6a0f9e3d-1b2c-4d5e-8f2a-8b02f60d92e4.jpg
+                                                    "
+                                    }
+                                    """)
+                    })
+            ),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 파일 확장자(png, jpg, jpeg만 허용)",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": "BAD_REQUEST",
+                                        "code" : "IMAGE-400-001",
+                                        "message": "이미지 타입이 유효하지 않습니다.(png, jpg, jpeg만 허용)"
+                                    }
+                                    """)
+                    })
+            ),
+    })
     ResponseEntity<?> uploadImage(@RequestParam("file") MultipartFile file, SecurityUserDetails userDetails);
 }

--- a/gotcha/src/main/java/Gotcha/domain/image/controller/ImageController.java
+++ b/gotcha/src/main/java/Gotcha/domain/image/controller/ImageController.java
@@ -1,0 +1,29 @@
+package Gotcha.domain.image.controller;
+
+import Gotcha.domain.image.api.ImageApi;
+import Gotcha.domain.image.service.ImageService;
+import gotcha_common.dto.SuccessRes;
+import gotcha_domain.auth.SecurityUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/image")
+@RequiredArgsConstructor
+public class ImageController implements ImageApi {
+
+    private final ImageService imageService;
+
+
+    @PostMapping("/upload")
+    public ResponseEntity<?> uploadImage(@RequestParam("file") MultipartFile file, SecurityUserDetails userDetails) {
+        String filename = imageService.uploadImage(userDetails.getUuid(), file);
+        return ResponseEntity.ok(SuccessRes.from(filename));
+    }
+
+}

--- a/gotcha/src/main/java/Gotcha/domain/image/controller/ImageController.java
+++ b/gotcha/src/main/java/Gotcha/domain/image/controller/ImageController.java
@@ -5,7 +5,9 @@ import Gotcha.domain.image.service.ImageService;
 import gotcha_common.dto.SuccessRes;
 import gotcha_domain.auth.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,13 +17,14 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/v1/image")
 @RequiredArgsConstructor
+@Slf4j
 public class ImageController implements ImageApi {
 
     private final ImageService imageService;
 
 
     @PostMapping("/upload")
-    public ResponseEntity<?> uploadImage(@RequestParam("file") MultipartFile file, SecurityUserDetails userDetails) {
+    public ResponseEntity<?> uploadImage(@RequestParam("file") MultipartFile file, @AuthenticationPrincipal SecurityUserDetails userDetails) {
         String filename = imageService.uploadImage(userDetails.getUuid(), file);
         return ResponseEntity.ok(SuccessRes.from(filename));
     }

--- a/gotcha/src/main/java/Gotcha/domain/image/exception/ImageExceptionCode.java
+++ b/gotcha/src/main/java/Gotcha/domain/image/exception/ImageExceptionCode.java
@@ -1,0 +1,30 @@
+package Gotcha.domain.image.exception;
+
+import gotcha_common.exception.exceptionCode.ExceptionCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum ImageExceptionCode implements ExceptionCode {
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE-400-001", "이미지 타입이 유효하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/gotcha/src/main/java/Gotcha/domain/image/exception/ImageExceptionCode.java
+++ b/gotcha/src/main/java/Gotcha/domain/image/exception/ImageExceptionCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum ImageExceptionCode implements ExceptionCode {
-    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE-400-001", "이미지 타입이 유효하지 않습니다.");
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE-400-001", "이미지 타입이 유효하지 않습니다.(png, jpg, jpeg만 허용)");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha/src/main/java/Gotcha/domain/image/service/ImageService.java
+++ b/gotcha/src/main/java/Gotcha/domain/image/service/ImageService.java
@@ -1,0 +1,40 @@
+package Gotcha.domain.image.service;
+
+import Gotcha.domain.image.exception.ImageExceptionCode;
+import gotcha_common.exception.CustomException;
+import gotcha_common.s3.S3ClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3ClientService s3ClientService;
+
+    public String uploadImage(String userUuid, MultipartFile file) {
+        String filename = generateUserFileName(userUuid, file);
+        s3ClientService.uploadFile(filename, file);
+        return filename;
+    }
+
+    private String generateUserFileName(String userUuid, MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        String extension = "";
+
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+
+        if(extension.isEmpty() || (!extension.equals(".jpg") && !extension.equals(".png") && !extension.equals(".jpeg"))){
+            throw new CustomException(ImageExceptionCode.INVALID_IMAGE_TYPE);
+        }
+
+        String uuid = UUID.randomUUID().toString();
+        return userUuid + "/" + uuid + extension;
+    }
+
+}

--- a/gotcha/src/main/resources/application-dev.yml
+++ b/gotcha/src/main/resources/application-dev.yml
@@ -28,7 +28,16 @@ spring:
           timeout: 5000
           starttls:
             enable: true
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_S3_ACCESS_KEY}
+        secret-key: ${AWS_S3_SECRET_KEY}
+      s3:
+        bucket-name: ${AWS_S3_BUCKET_NAME}
 
+      region:
+        static: ${AWS_S3_REGION}
   data:
     redis:
       host: ${REDIS_HOST:localhost}


### PR DESCRIPTION
# S3 이미지 업로드 기능 구현

## 📝 개요  

이미지 파일을 받아 S3에 업로드 하는 기능을 구현하였습니다. 

---

## ⚙️ 구현 내용  

이미지 파일(MultipartFile)을 받아 S3에 업로드하는 기능을 구현하였습니다.  

파일 업로드 시 사용자별 디렉토리에 UUID 기반 파일명을 생성하여 저장하도록 처리하였습니다.  

이미지 파일(.jpg, .png, .jpeg) 외의 업로드 요청에 대해서는 예외를 반환하도록 검증 로직도 추가하였습니다.

업로드 성공 시 OK와 함께 S3 버킷의 베이스 URL을 제외한 `/{userUUID}/{imageUUID}` 경로가 반환됩니다. 


---

## 🧪 테스트 결과  

![image](https://github.com/user-attachments/assets/870f7423-3c9c-444e-b511-a2f9ab02c2e0)

---
