### PR TITLE
feat: 닉네임 변경 기능 구현

### DIFF
--- a/gotcha-domain/src/main/java/gotcha_domain/user/User.java
+++ b/gotcha-domain/src/main/java/gotcha_domain/user/User.java
@@ -119,4 +119,8 @@ public class User extends BaseTimeEntity {
         this.role = role;
         this.uuid = uuid;
     }
+
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
 }

--- a/gotcha-user/src/main/java/gotcha_user/exceptionCode/UserExceptionCode.java
+++ b/gotcha-user/src/main/java/gotcha_user/exceptionCode/UserExceptionCode.java
@@ -11,7 +11,9 @@ public enum UserExceptionCode implements ExceptionCode {
 
     NICKNAME_EXIST(HttpStatus.CONFLICT, "USER-409-001", "이미 존재하는 닉네임입니다."),
     EMAIL_EXIST(HttpStatus.CONFLICT, "USER-409-002", "이미 가입된 이메일입니다."),
-    INVALID_USERID(HttpStatus.NOT_FOUND, "USER-404-001", "존재하지 않는 사용자입니다.");
+    SAME_NICKNAME(HttpStatus.CONFLICT, "USER-409-003", "현재 닉네임과 동일합니다."),
+    INVALID_USERID(HttpStatus.NOT_FOUND, "USER-404-001", "존재하지 않는 사용자입니다."),
+    NICKNAME_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER-400-001", "닉네임 중복 확인이 되지 않았습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha-user/src/main/java/gotcha_user/service/UserService.java
+++ b/gotcha-user/src/main/java/gotcha_user/service/UserService.java
@@ -55,6 +55,24 @@ public class UserService {
         return UserInfoRes.fromEntity(user);
     }
 
+    @Transactional
+    public void changeNickname(Long userId, String nickname) {
+        if (!"true".equals(redisUtil.getData(NICKNAME_VERIFY_KEY_PREFIX + nickname))) {
+            throw new CustomException(UserExceptionCode.NICKNAME_NOT_VERIFIED);
+        }
+
+        if (userRepository.existsByNickname(nickname)) {
+            throw new CustomException(UserExceptionCode.NICKNAME_EXIST);
+        }
+
+        User user = findUserByUserId(userId);
+        if (user.getNickname().equals(nickname)) {
+            throw new CustomException(UserExceptionCode.SAME_NICKNAME);
+        }
+
+        user.changeNickname(nickname);
+    }
+
     @Transactional(readOnly = true)
     public User findUserByUserId(Long userId){
         return userRepository.findById(userId)

--- a/gotcha/src/main/java/Gotcha/domain/mypage/controller/MypageController.java
+++ b/gotcha/src/main/java/Gotcha/domain/mypage/controller/MypageController.java
@@ -2,12 +2,17 @@ package Gotcha.domain.mypage.controller;
 
 import Gotcha.domain.mypage.api.MypageApi;
 import Gotcha.domain.mypage.service.MypageService;
+import gotcha_common.dto.SuccessRes;
 import gotcha_domain.auth.SecurityUserDetails;
+import gotcha_user.dto.NicknameReq;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/mypage")
 public class MypageController implements MypageApi {
     private final MypageService mypageService;
-    
+
     @GetMapping("/games")
     public ResponseEntity<?> getUserGameSummaries(@AuthenticationPrincipal SecurityUserDetails userDetails) {
         return ResponseEntity.ok(mypageService.getUserGameSummaries(userDetails.getId()));
@@ -26,5 +31,12 @@ public class MypageController implements MypageApi {
     public ResponseEntity<?> getUserGameDetails(@PathVariable(value = "id") Long gameId,
                                                 @AuthenticationPrincipal SecurityUserDetails userDetails) {
         return ResponseEntity.ok(mypageService.getUserGameDetail(gameId, userDetails.getId()));
+    }
+
+    @PutMapping("/nickname")
+    public ResponseEntity<?> modifyUserNickname(@Valid @RequestBody NicknameReq nicknameReq,
+                                                @AuthenticationPrincipal SecurityUserDetails userDetails) {
+        mypageService.modifyUserNickname(userDetails.getId(), nicknameReq.nickname());
+        return ResponseEntity.ok(SuccessRes.from("성공적으로 수정되었습니다."));
     }
 }

--- a/gotcha/src/main/java/Gotcha/domain/mypage/service/MypageService.java
+++ b/gotcha/src/main/java/Gotcha/domain/mypage/service/MypageService.java
@@ -3,6 +3,7 @@ package Gotcha.domain.mypage.service;
 import Gotcha.domain.gamehistory.dto.UserGameHistoryDetailRes;
 import Gotcha.domain.gamehistory.dto.UserGameHistorySummaryRes;
 import Gotcha.domain.gamehistory.service.GameHistoryService;
+import gotcha_common.util.RedisUtil;
 import gotcha_domain.user.User;
 import gotcha_user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.List;
 public class MypageService {
     private final UserService userService;
     private final GameHistoryService gameHistoryService;
+    private final RedisUtil redisUtil;
 
     public List<UserGameHistorySummaryRes> getUserGameSummaries(Long userId) {
         User user = userService.findUserByUserId(userId);
@@ -26,5 +28,9 @@ public class MypageService {
         User user = userService.findUserByUserId(userId);
 
         return gameHistoryService.getUserGameDetail(gameId, userId);
+    }
+
+    public void modifyUserNickname(Long userId, String nickname) {
+        userService.changeNickname(userId, nickname);
     }
 }

--- a/gotcha/src/main/java/Gotcha/domain/mypage/service/MypageService.java
+++ b/gotcha/src/main/java/Gotcha/domain/mypage/service/MypageService.java
@@ -8,6 +8,7 @@ import gotcha_domain.user.User;
 import gotcha_user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,18 +19,21 @@ public class MypageService {
     private final GameHistoryService gameHistoryService;
     private final RedisUtil redisUtil;
 
+    @Transactional(readOnly = true)
     public List<UserGameHistorySummaryRes> getUserGameSummaries(Long userId) {
         User user = userService.findUserByUserId(userId);
 
         return gameHistoryService.getUserGameHistories(userId);
     }
 
+    @Transactional(readOnly = true)
     public UserGameHistoryDetailRes getUserGameDetail(Long gameId, Long userId) {
         User user = userService.findUserByUserId(userId);
 
         return gameHistoryService.getUserGameDetail(gameId, userId);
     }
 
+    @Transactional
     public void modifyUserNickname(Long userId, String nickname) {
         userService.changeNickname(userId, nickname);
     }


### PR DESCRIPTION
# 닉네임 변경 기능 구현

## 📝 개요  

닉네임 변경 기능 구현

---

## ⚙️ 구현 내용  

마이페이지에서의 닉네임 변경 기능을 구현하였습니다.

기존에 회원가입 시에 사용했던 닉네임 중복 검사를 미리 한 후, 해당 과정을 통해 닉네임을 변경할 수 있습니다.
전체적인 로직은 회원가입과 큰 차이가 없는 것 같습니다.

---