### PR TITLE
refact: 대기방 목록 조회 시 게임 모드에 따른 분류 로직 추가

### DIFF
--- a/gotcha-socket/src/main/java/socket_server/domain/room/dto/RoomListReq.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/dto/RoomListReq.java
@@ -1,0 +1,16 @@
+package socket_server.domain.room.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import socket_server.domain.game.enumType.Difficulty;
+import socket_server.domain.game.enumType.GameType;
+
+public record RoomListReq(
+        @Schema(description = "게임 모드", examples = "TRICK_MYOMYO")
+        @NotNull(message = "게임 모드는 필수입니다.")
+        GameType gameType,
+
+        @Schema(description = "인공지능 난이도", examples = "BASIC")
+        Difficulty difficulty
+) {
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/room/dto/RoomSummaryRes.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/dto/RoomSummaryRes.java
@@ -1,11 +1,15 @@
 package socket_server.domain.room.dto;
 
+import socket_server.domain.game.enumType.Difficulty;
+import socket_server.domain.game.enumType.GameType;
 import socket_server.domain.room.model.RoomMetadata;
 
 public record RoomSummaryRes(
         String roomId,
         String title,
         String owner,
+        GameType gameType,
+        Difficulty difficulty,
         boolean hasPassword,
         int maxUser,
         int currentUser
@@ -15,6 +19,8 @@ public record RoomSummaryRes(
                 metadata.getId(),
                 metadata.getTitle(),
                 metadata.getOwner(),
+                metadata.getGameType(),
+                metadata.getDifficulty(),
                 metadata.isHasPassword(),
                 metadata.getMax(),
                 currentUser

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -20,6 +20,7 @@ import socket_server.domain.lobby.service.LobbyBroadCaster;
 import socket_server.domain.room.RoomField.RoomField;
 import socket_server.domain.room.dto.EventRes;
 import socket_server.domain.room.dto.RoomInfoRes;
+import socket_server.domain.room.dto.RoomListReq;
 import socket_server.domain.room.dto.RoomSummaryRes;
 import socket_server.domain.room.dto.RoomUpdateReq;
 import socket_server.domain.room.model.RoomEventType;
@@ -182,8 +183,9 @@ public class RoomService {
         return RoomMetadata.fromRedisMap(roomId, fields);
     }
 
-    public List<RoomSummaryRes> getAllRoomSummaries() {
+    public List<RoomSummaryRes> getAllRoomSummaries(RoomListReq roomListReq) {
         Set<String> allRoomIds = roomRepository.getAllRoomIds();
+
         return allRoomIds.stream()
                 .map(roomId -> {
                     Map<Object, Object> roomData = roomRepository.getRoomData(roomId);
@@ -192,12 +194,21 @@ public class RoomService {
                     }
 
                     RoomMetadata metadata = RoomMetadata.fromRedisMap(roomId, roomData);
+
+                    if (!metadata.getGameType().equals(roomListReq.gameType())) {
+                        return null;
+                    }
+                    if (roomListReq.difficulty() != null && !roomListReq.difficulty().equals(metadata.getDifficulty())) {
+                        return null;
+                    }
+
                     int currentUser = roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR).size();
                     return RoomSummaryRes.of(metadata, currentUser);
                 })
                 .filter(Objects::nonNull)
                 .toList();
     }
+
 
     public RoomDetailRes getRoomDetails(String roomId, String userUuid) {
         Map<Object, Object> roomData = roomRepository.getRoomData(roomId);

--- a/gotcha/src/main/java/Gotcha/domain/room/api/RoomApi.java
+++ b/gotcha/src/main/java/Gotcha/domain/room/api/RoomApi.java
@@ -1,5 +1,6 @@
 package Gotcha.domain.room.api;
 
+import socket_server.domain.room.dto.RoomListReq;
 import gotcha_domain.auth.SecurityUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[대기방 API]", description = "대기방 관련 API")
 public interface RoomApi {
@@ -19,19 +21,31 @@ public interface RoomApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                     [
-                                        {
-                                            "roomId": "5876",
-                                            "title": "고양이의 비밀방",
-                                            "owner": "관리자",
-                                            "hasPassword": true,
-                                            "maxUser": 2,
-                                            "currentUser": 2
-                                        }
+                                         {
+                                             "roomId": "7390",
+                                             "title": "고양이를 속여보자",
+                                             "owner": "관리자",
+                                             "gameType": "TRICK_MYOMYO",
+                                             "difficulty": "BASIC",
+                                             "hasPassword": false,
+                                             "maxUser": 2,
+                                             "currentUser": 1
+                                         },
+                                         {
+                                             "roomId": "7705",
+                                             "title": "고양이의 비밀방",
+                                             "owner": "테스터",
+                                             "gameType": "TRICK_MYOMYO",
+                                             "difficulty": "ADVANCED",
+                                             "hasPassword": false,
+                                             "maxUser": 2,
+                                             "currentUser": 1
+                                         }
                                     ]
                                     """)
                     }))
     })
-    ResponseEntity<?> getRoomSummaries();
+    ResponseEntity<?> getRoomSummaries(@RequestBody RoomListReq roomListReq);
 
     @Operation(summary = "대기방 상세 정보 조회", description = "대기방 입장 시 초기 상세 정보 조회 API")
     @ApiResponses({

--- a/gotcha/src/main/java/Gotcha/domain/room/controller/RoomController.java
+++ b/gotcha/src/main/java/Gotcha/domain/room/controller/RoomController.java
@@ -1,12 +1,15 @@
 package Gotcha.domain.room.controller;
 
 import Gotcha.domain.room.api.RoomApi;
+import socket_server.domain.room.dto.RoomListReq;
 import gotcha_domain.auth.SecurityUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import socket_server.domain.room.service.RoomService;
@@ -18,8 +21,8 @@ public class RoomController implements RoomApi {
     private final RoomService roomService;
 
     @GetMapping()
-    public ResponseEntity<?> getRoomSummaries() {
-        return ResponseEntity.ok(roomService.getAllRoomSummaries());
+    public ResponseEntity<?> getRoomSummaries(@RequestBody @Valid RoomListReq roomListReq) {
+        return ResponseEntity.ok(roomService.getAllRoomSummaries(roomListReq));
     }
 
     @GetMapping("/{roomId}")


### PR DESCRIPTION
# 대기방 목록 조회 시 게임 모드에 따른 분류 로직 추가

## 📝 개요  

대기방 목록 조회 시 게임 모드에 따른 분류 로직 추가

---

## ⚙️ 구현 내용  

대기방 목록 조회 시 게임 모드, 난이도에 따라 목록을 반환하도록 하였습니다.

RoomListReq을 통해 게임모드는 필수적으로 받도록 하였고, 난이도는 선택적으로 받아 사용자가 선택적으로 필터링을 통해 대기방을 조회할 수 있도록 하였습니다.

기존의 RoomSummaryRes에는 게임모드, 난이도를 리턴해주지 않아 해당 요소들도 함께 리턴해주도록 하였습니다.

---

## 🧪 테스트 결과  

묘묘를 속여라
<img width="644" alt="image" src="https://github.com/user-attachments/assets/919cfbb2-e10e-4ab6-b390-c1536771774b" />

토선생 미대입시(방 없음)
<img width="590" alt="image" src="https://github.com/user-attachments/assets/5aa0b081-d66b-4cf6-b4e5-cda8e621aa06" />

난이도 필터링
<img width="650" alt="image" src="https://github.com/user-attachments/assets/26cc88c6-738d-4c7f-8233-9c586b50e7df" />

---
