### PR TITLE
feat: game2 로직 API 구현

### DIFF
--- a/gotcha-common/build.gradle
+++ b/gotcha-common/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     implementation 'jakarta.mail:jakarta.mail-api:2.1.2'
 
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:${springCloudAwsVersion}")

--- a/gotcha-common/src/main/java/gotcha_common/config/WebClientConfig.java
+++ b/gotcha-common/src/main/java/gotcha_common/config/WebClientConfig.java
@@ -1,4 +1,4 @@
-package socket_server.common.config;
+package gotcha_common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/gotcha-socket/src/main/java/socket_server/domain/game/service/AIClientService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/service/AIClientService.java
@@ -1,6 +1,6 @@
 package socket_server.domain.game.service;
 
-import gotcha_common.exception.CustomException;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/gotcha/build.gradle
+++ b/gotcha/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/gotcha/src/main/java/Gotcha/domain/lulu/api/LuLuApi.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/api/LuLuApi.java
@@ -1,0 +1,66 @@
+package Gotcha.domain.lulu.api;
+
+
+import Gotcha.domain.lulu.dto.TaskEvalReq;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.media.Content;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "[LULU GAME API]", description = "LULU GAME 관련 API")
+public interface LuLuApi {
+
+    @Operation(summary = "게임 시작", description = "게임 시작 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게임 시작 성공, message 필드에는 발급된 gameID가 반환됩니다.",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": "OK",
+                                        "message": "1234"
+                                    }
+                                """)
+                    })
+            )
+    })
+    ResponseEntity<?> startGame();
+
+
+    @Operation(summary = "키워드 제시", description = "키워드 제시 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "키워드 제시 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "game_id": "7550",
+                                        "keyword": "나비",
+                                        "situation": "달빛이 흠뻑 젖은 새벽, 투명한 숨결이 바람에 실려 흔들린다. 무엇인가 아주 가벼운 것이, 찢어진 구름 사이를 맴돌며 잊혀진 약속을 속삭인다. 색도 소리도 없는 경계에서, 그 존재는 언제나 날갯짓 하나로 모든 것을 바꿀 듯 아슬아슬하게 머문다."
+                                    }
+                                """)
+                    })
+            )
+    })
+    ResponseEntity<?> generateTask(@PathVariable(value="gameId") String gameId);
+
+
+    @Operation(summary = "키워드 평가", description = "키워드 평가 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "키워드 평가 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "score": 80,
+                                        "feedback": "Good Job",
+                                        "game_id": "7550"
+                                    }
+                                """)
+                    })
+            )
+    })
+    ResponseEntity<?> evaluateTask(@PathVariable(value="gameId") String gameId, @RequestBody TaskEvalReq taskEvalReq);
+}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/controller/LuLuController.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/controller/LuLuController.java
@@ -1,6 +1,7 @@
 package Gotcha.domain.lulu.controller;
 
 
+import Gotcha.domain.lulu.api.LuLuApi;
 import Gotcha.domain.lulu.dto.TaskEvalReq;
 import Gotcha.domain.lulu.dto.TaskEvalRes;
 import Gotcha.domain.lulu.dto.TaskStartRes;
@@ -13,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/game")
-public class LuLuController {
+public class LuLuController implements LuLuApi {
 
     private final LuLuAIClientService luLuAIClientService;
 

--- a/gotcha/src/main/java/Gotcha/domain/lulu/controller/LuLuController.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/controller/LuLuController.java
@@ -1,0 +1,37 @@
+package Gotcha.domain.lulu.controller;
+
+
+import Gotcha.domain.lulu.dto.TaskEvalReq;
+import Gotcha.domain.lulu.dto.TaskEvalRes;
+import Gotcha.domain.lulu.dto.TaskStartRes;
+import Gotcha.domain.lulu.service.LuLuAIClientService;
+import gotcha_common.dto.SuccessRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/game")
+public class LuLuController {
+
+    private final LuLuAIClientService luLuAIClientService;
+
+    @GetMapping("/lulu/start")
+    public ResponseEntity<?> startGame() {
+        return ResponseEntity.ok().body(SuccessRes.from(luLuAIClientService.startGame().gameId()));
+    }
+
+    @GetMapping("/lulu/task/{gameId}")
+    public ResponseEntity<?> generateTask(@PathVariable String gameId) {
+        return ResponseEntity.ok().body(luLuAIClientService.generateTask(gameId));
+    }
+
+
+    @PostMapping("/lulu/evaluate/{gameId}")
+    public ResponseEntity<?> evaluateTask(@PathVariable String gameId, @RequestBody TaskEvalReq taskEvalReq) {
+        return ResponseEntity.ok().body(luLuAIClientService.evaluateTask(gameId, taskEvalReq));
+    }
+
+
+}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/dto/StartRes.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/dto/StartRes.java
@@ -1,0 +1,9 @@
+package Gotcha.domain.lulu.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record StartRes(
+    @JsonProperty("game_id")
+    String gameId
+) {
+}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskEvalReq.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskEvalReq.java
@@ -1,6 +1,6 @@
 package Gotcha.domain.lulu.dto;
 
 public record TaskEvalReq(
-        String description
+        String imageURL
 ) {
 }

--- a/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskEvalReq.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskEvalReq.java
@@ -1,0 +1,6 @@
+package Gotcha.domain.lulu.dto;
+
+public record TaskEvalReq(
+        String description
+) {
+}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskEvalRes.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskEvalRes.java
@@ -1,0 +1,21 @@
+package Gotcha.domain.lulu.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TaskEvalRes(
+        Integer score,
+        String feedback,
+        Task task,
+        @JsonProperty("game_id")
+        String gameId
+) {
+}
+
+class Task{
+    @JsonProperty("hidden_keyword")
+    String keyword;
+    @JsonProperty("poestic_description")
+    String description;
+    @JsonProperty("game_id")
+    String gameId;
+}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskEvalRes.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskEvalRes.java
@@ -5,17 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record TaskEvalRes(
         Integer score,
         String feedback,
-        Task task,
         @JsonProperty("game_id")
         String gameId
 ) {
 }
 
-class Task{
-    @JsonProperty("hidden_keyword")
-    String keyword;
-    @JsonProperty("poestic_description")
-    String description;
-    @JsonProperty("game_id")
-    String gameId;
-}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskStartRes.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskStartRes.java
@@ -1,0 +1,7 @@
+package Gotcha.domain.lulu.dto;
+
+public record TaskStartRes(
+        String keyword,
+        String situation
+) {
+}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskStartRes.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/dto/TaskStartRes.java
@@ -1,6 +1,10 @@
 package Gotcha.domain.lulu.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record TaskStartRes(
+        @JsonProperty("game_id")
+        String gameId,
         String keyword,
         String situation
 ) {

--- a/gotcha/src/main/java/Gotcha/domain/lulu/exception/LuLuExceptionCode.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/exception/LuLuExceptionCode.java
@@ -1,0 +1,29 @@
+package Gotcha.domain.lulu.exception;
+
+import gotcha_common.exception.exceptionCode.ExceptionCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum LuLuExceptionCode implements ExceptionCode {
+    AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "LULU-500-001", "AI 서버 내부 오류입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/exception/LuLuExceptionCode.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/exception/LuLuExceptionCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum LuLuExceptionCode implements ExceptionCode {
-    AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "LULU-500-001", "AI 서버 내부 오류입니다.");
+    AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "LULU-500-001", "AI 서버 내부 오류입니다."),
+    AI_SERVER_FORMAT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "LULU-500-002", "AI 서버 데이터 파싱에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha/src/main/java/Gotcha/domain/lulu/service/LuLuAIClientService.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/service/LuLuAIClientService.java
@@ -1,0 +1,100 @@
+package Gotcha.domain.lulu.service;
+
+import Gotcha.domain.lulu.dto.StartRes;
+import Gotcha.domain.lulu.dto.TaskEvalReq;
+import Gotcha.domain.lulu.dto.TaskEvalRes;
+import Gotcha.domain.lulu.dto.TaskStartRes;
+import Gotcha.domain.lulu.exception.LuLuExceptionCode;
+import gotcha_common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LuLuAIClientService {
+
+    private final WebClient webClient;
+
+    @Value("${ai-server.url}")
+    private String AI_SERVER_BASE_URL;
+
+
+    /**
+     * 루루 게임 시작. 게임ID 발급받음
+     */
+    public StartRes startGame(){
+        try {
+            StartRes res = webClient.get()
+                    .uri(AI_SERVER_BASE_URL + "lulu/start")
+                    .retrieve()
+                    .onStatus(httpStatusCode -> httpStatusCode.is4xxClientError() || httpStatusCode.is5xxServerError()
+                            , clientResponse -> clientResponse.bodyToMono(String.class).flatMap(error -> Mono.error(
+                                    new CustomException(LuLuExceptionCode.AI_SERVER_ERROR))))
+                    .bodyToMono(StartRes.class)
+                    .block();
+            if (res == null || res.gameId() == null)
+                throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
+            return res;
+        } catch (Exception e) {
+            log.error("LuLuAIClientService startGame error", e);
+            throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
+        }
+    }
+
+
+    /**
+     * 루루 키워드 제시
+     */
+    public TaskStartRes generateTask(String gameId){
+        try {
+            TaskStartRes res = webClient.get()
+                    .uri(AI_SERVER_BASE_URL + "lulu/task/" + gameId)
+                    .retrieve()
+                    .onStatus(httpStatusCode -> httpStatusCode.is4xxClientError() || httpStatusCode.is5xxServerError(
+                            )
+                            , clientResponse -> clientResponse.bodyToMono(String.class).flatMap(error -> Mono.error(
+                                    new CustomException(LuLuExceptionCode.AI_SERVER_ERROR))))
+                    .bodyToMono(TaskStartRes.class)
+                    .block();
+            if (res == null || res.keyword() == null || res.situation() == null)
+                throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
+            return res;
+        } catch (Exception e) {
+            log.error("LuLuAIClientService generateTask error", e);
+            throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
+        }
+    }
+
+
+    /**
+     * 루루 키워드 평가
+     */
+    public TaskEvalRes evaluateTask(String gameId, TaskEvalReq taskEvalReq){
+        try {
+            TaskEvalRes res = webClient.post()
+                    .uri(AI_SERVER_BASE_URL + "lulu/task" + gameId)
+                    .bodyValue(taskEvalReq)
+                    .retrieve()
+                    .onStatus(httpStatusCode -> httpStatusCode.is4xxClientError() || httpStatusCode.is5xxServerError(
+                            )
+                            , clientResponse -> clientResponse.bodyToMono(String.class).flatMap(error -> Mono.error(
+                                    new CustomException(LuLuExceptionCode.AI_SERVER_ERROR))))
+                    .bodyToMono(TaskEvalRes.class)
+                    .block();
+            if (res == null || res.score() == null || res.feedback() == null || res.task() == null)
+                throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
+            return res;
+        } catch (Exception e) {
+            log.error("LuLuAIClientService evaluateTask error", e);
+            throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
+        }
+    }
+
+
+
+}

--- a/gotcha/src/main/java/Gotcha/domain/lulu/service/LuLuAIClientService.java
+++ b/gotcha/src/main/java/Gotcha/domain/lulu/service/LuLuAIClientService.java
@@ -11,7 +11,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -40,7 +43,7 @@ public class LuLuAIClientService {
             if (res == null || res.gameId() == null)
                 throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
             return res;
-        } catch (Exception e) {
+        } catch (WebClientResponseException e) {
             log.error("LuLuAIClientService startGame error", e);
             throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
         }
@@ -61,10 +64,12 @@ public class LuLuAIClientService {
                                     new CustomException(LuLuExceptionCode.AI_SERVER_ERROR))))
                     .bodyToMono(TaskStartRes.class)
                     .block();
-            if (res == null || res.keyword() == null || res.situation() == null)
+            if (res == null || res.keyword() == null || res.situation() == null){
+                log.error(String.valueOf(res));
                 throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
+            }
             return res;
-        } catch (Exception e) {
+        } catch (WebClientResponseException e) {
             log.error("LuLuAIClientService generateTask error", e);
             throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
         }
@@ -75,10 +80,16 @@ public class LuLuAIClientService {
      * 루루 키워드 평가
      */
     public TaskEvalRes evaluateTask(String gameId, TaskEvalReq taskEvalReq){
+        String caption = getImageCaption(taskEvalReq.imageURL());
+        return requestEvaluate(gameId, caption);
+    }
+
+    private TaskEvalRes requestEvaluate(String gameId, String imageCaption){
+        Map<String, String> body = Map.of("description", imageCaption);
         try {
             TaskEvalRes res = webClient.post()
-                    .uri(AI_SERVER_BASE_URL + "lulu/task" + gameId)
-                    .bodyValue(taskEvalReq)
+                    .uri(AI_SERVER_BASE_URL + "lulu/task/" + gameId)
+                    .bodyValue(body)
                     .retrieve()
                     .onStatus(httpStatusCode -> httpStatusCode.is4xxClientError() || httpStatusCode.is5xxServerError(
                             )
@@ -86,15 +97,35 @@ public class LuLuAIClientService {
                                     new CustomException(LuLuExceptionCode.AI_SERVER_ERROR))))
                     .bodyToMono(TaskEvalRes.class)
                     .block();
-            if (res == null || res.score() == null || res.feedback() == null || res.task() == null)
+            if (res == null || res.score() == null || res.feedback() == null || res.gameId() == null)
                 throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
             return res;
-        } catch (Exception e) {
+        } catch (WebClientResponseException e) {
             log.error("LuLuAIClientService evaluateTask error", e);
             throw new CustomException(LuLuExceptionCode.AI_SERVER_FORMAT_ERROR);
         }
     }
 
+
+
+
+
+    /**
+     * 이미지 캡셔닝
+     */
+    public String getImageCaption(String imageUrl){
+        Map<String, String> body = Map.of("imageURL", imageUrl);
+        return webClient.post()
+                .uri(AI_SERVER_BASE_URL + "image/caption")
+                .bodyValue(body)
+                .retrieve()
+                .onStatus(httpStatusCode -> httpStatusCode.is4xxClientError() || httpStatusCode.is5xxServerError(
+                        )
+                        , clientResponse -> clientResponse.bodyToMono(String.class).flatMap(error -> Mono.error(
+                                new CustomException(LuLuExceptionCode.AI_SERVER_ERROR))))
+                .bodyToMono(String.class)
+                .block();
+    }
 
 
 }


### PR DESCRIPTION
# game2 구현

## 📝 개요  

게임2 (루루의 미대입시) API를 구현하였습니다.


---

## ⚙️ 구현 내용  

게임의 전체 컨텍스트는 아래와 같습니다.

1. 클라이언트의 게임 시작 요청 -> AI 서버에서 gameID 발급
2. 게임 ID와 함께 제시어 요청 -> AI 서버에서 제시어, 설명 생성 후 반환
3. 설명을 보고 그림 URL 제출 -> AI 서버에서 이미지를 텍스트로 변환
4. Spring 서버에서 변환된 이미지 텍스트를 AI 서버로 제출 -> 평가 결과 반환

해당 PR에 작성된 코드들은, 클라이언트와 AI 서버를 연결해주는 성격이 강합니다. 
AI 서버 관련 자세한 구현은 https://github.com/GotchaAI/BE-AI-SERVER 의 src/chat/lulu.py, src/image/img_caption.py 를 참조하시면 됩니다.


---

## 📎 기타

게임 종료 후 사용자 정보 업데이트(레벨, 경험치) 와 게임 기록 DB 저장은 아직 작성되지 않았습니다.

---

## 🧪 테스트 결과  

### 게임 시작

![image](https://github.com/user-attachments/assets/76829556-5228-4888-b5e5-efa139050c50)

### 제시어, 상황 생성

![image](https://github.com/user-attachments/assets/033e8870-d411-4213-8ccc-77bd653dffa2)

### 평가
![image](https://github.com/user-attachments/assets/1fc78a38-73eb-43e6-897a-01756e8d5fa8)

---
