### PR TITLE
feat: 사용자 소켓 연결 해제 후 대기방 자동 퇴장 및 재접속 로직 작성

### DIFF
--- a/gotcha-socket/src/main/java/socket_server/common/config/RedisExpirationConfig.java
+++ b/gotcha-socket/src/main/java/socket_server/common/config/RedisExpirationConfig.java
@@ -1,0 +1,29 @@
+package socket_server.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import socket_server.common.listener.RedisKeyExpirationListener;
+import socket_server.domain.room.service.RoomUserService;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisExpirationConfig {
+
+    private final RedisConnectionFactory connectionFactory;
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+
+    @Bean
+    public RedisKeyExpirationListener redisKeyExpirationListener(RedisMessageListenerContainer container, RoomUserService roomUserService) {
+        return new RedisKeyExpirationListener(container, roomUserService);
+    }
+}
+

--- a/gotcha-socket/src/main/java/socket_server/common/exception/room/RoomExceptionCode.java
+++ b/gotcha-socket/src/main/java/socket_server/common/exception/room/RoomExceptionCode.java
@@ -18,7 +18,8 @@ public enum RoomExceptionCode implements ExceptionCode {
     NOT_ALL_PLAYER_READY(HttpStatus.BAD_REQUEST, "ROOM_400_008", "모든 유저가 준비되지 않았습니다."),
     INVALID_GAME_PLAYERS(HttpStatus.BAD_REQUEST, "ROOM_400_009", "게임 시작에 필요한 유저 수가 올바르지 않습니다."),
     CANNOT_KICK_SELF(HttpStatus.BAD_REQUEST, "ROOM_400_010", "자기 자신을 강퇴할 수 없습니다."),
-    ROOM_IS_FULL(HttpStatus.BAD_REQUEST, "ROOM_400_011", "이미 방이 가득 찼어요!");
+    ROOM_IS_FULL(HttpStatus.BAD_REQUEST, "ROOM_400_011", "이미 방이 가득 찼어요!"),
+    RECONNECT_ROOM_EXPIRED(HttpStatus.BAD_REQUEST, "ROOM_400_012", "재접속 가능한 방 정보가 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha-socket/src/main/java/socket_server/common/listener/RedisKeyExpirationListener.java
+++ b/gotcha-socket/src/main/java/socket_server/common/listener/RedisKeyExpirationListener.java
@@ -1,0 +1,31 @@
+package socket_server.common.listener;
+
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+import socket_server.domain.room.service.RoomUserService;
+
+@Component
+public class RedisKeyExpirationListener extends KeyExpirationEventMessageListener {
+
+    private final RoomUserService roomUserService;
+
+    public RedisKeyExpirationListener(RedisMessageListenerContainer listenerContainer, RoomUserService roomUserService) {
+        super(listenerContainer);
+        this.roomUserService = roomUserService;
+    }
+
+    @Override
+    public void onMessage(org.springframework.data.redis.connection.Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+
+        if (expiredKey.startsWith("disconnect:room:")) {
+            String userUuid = expiredKey.replace("disconnect:room:", "");
+            String roomId = roomUserService.findRoomIdByUserUuid(userUuid);
+
+            if (roomId != null) {
+                roomUserService.exitRoom(roomId, userUuid);
+            }
+        }
+    }
+}

--- a/gotcha-socket/src/main/java/socket_server/common/listener/WebSocketDisconnectListener.java
+++ b/gotcha-socket/src/main/java/socket_server/common/listener/WebSocketDisconnectListener.java
@@ -1,0 +1,40 @@
+package socket_server.common.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import socket_server.common.util.DisconnectManager;
+import socket_server.domain.room.service.RoomUserService;
+
+import java.security.Principal;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class WebSocketDisconnectListener {
+
+    private final RoomUserService roomUserService;
+    private final DisconnectManager disconnectManager;
+
+    @EventListener
+    public void onDisconnect(SessionDisconnectEvent event) {
+        Principal principal = event.getUser();
+
+        if (principal instanceof Authentication auth) {
+            String userUuid = auth.getName();
+
+            log.info(userUuid + " 소켓 연결 해제!");
+            if (userUuid == null) return;
+
+            String roomId = roomUserService.findRoomIdByUserUuid(userUuid);
+            if (roomId != null) {
+                disconnectManager.markDisconnect(userUuid, roomId);
+            }
+        }
+
+    }
+}
+

--- a/gotcha-socket/src/main/java/socket_server/common/util/DisconnectManager.java
+++ b/gotcha-socket/src/main/java/socket_server/common/util/DisconnectManager.java
@@ -1,0 +1,36 @@
+package socket_server.common.util;
+
+import gotcha_common.exception.CustomException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import socket_server.common.exception.room.RoomExceptionCode;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class DisconnectManager {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String PREFIX = "disconnect:room:";
+
+    public DisconnectManager(@Qualifier("socketStringRedisTemplate")
+                             RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void markDisconnect(String userUuid, String roomId) {
+        redisTemplate.opsForValue().set(PREFIX + userUuid, roomId, 30, TimeUnit.SECONDS);
+    }
+
+    public String cancelDisconnectIfExists(String userUuid) {
+        String key = PREFIX + userUuid;
+        String roomId = redisTemplate.opsForValue().get(key);
+        if (roomId == null) {
+            throw new CustomException(RoomExceptionCode.RECONNECT_ROOM_EXPIRED);
+        }
+        redisTemplate.delete(key);
+        return roomId;
+    }
+}
+

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -61,7 +61,7 @@ public class RoomUserService {
 
     public void exitRoom(String roomId, String userUuid) {
         processUserExit(roomId, userUuid, false);
-        broadcastExit(roomId, userUuid);
+//        broadcastExit(roomId, userUuid);
     }
 
     public String findRoomIdByUserUuid(String userUuid) {

--- a/gotcha/src/main/java/Gotcha/domain/ws/ReconnectController.java
+++ b/gotcha/src/main/java/Gotcha/domain/ws/ReconnectController.java
@@ -1,0 +1,25 @@
+package Gotcha.domain.ws;
+
+import gotcha_domain.auth.SecurityUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import socket_server.common.util.DisconnectManager;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/ws")
+@RequiredArgsConstructor
+public class ReconnectController {
+    private final DisconnectManager disconnectManager;
+
+    @GetMapping("/reconnect")
+    public ResponseEntity<?> reconnect(@AuthenticationPrincipal SecurityUserDetails userDetails) {
+        String roomId = disconnectManager.cancelDisconnectIfExists(userDetails.getUuid());
+        return ResponseEntity.ok(Map.of("roomId", roomId));
+    }
+}

--- a/gotcha/src/main/java/Gotcha/domain/ws/api/ReconnectApi.java
+++ b/gotcha/src/main/java/Gotcha/domain/ws/api/ReconnectApi.java
@@ -1,0 +1,38 @@
+package Gotcha.domain.ws.api;
+
+import gotcha_domain.auth.SecurityUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "[소켓 재접속 API]", description = "소켓 재접속 관련 API")
+public interface ReconnectApi {
+
+    @Operation(summary = "재접속 처리", description = "소켓 연결 해제 후 재접속 시 기존 대기방 반환 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재접속 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "roomId": "7705"
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "재접속 가능한 방이 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "code": "ROOM_400_012",
+                                        "status": "BAD_REQUEST",
+                                        "message": "재접속 가능한 방 정보가 없습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> reconnect(@AuthenticationPrincipal SecurityUserDetails userDetails);
+}

--- a/gotcha/src/main/java/Gotcha/domain/ws/controller/ReconnectController.java
+++ b/gotcha/src/main/java/Gotcha/domain/ws/controller/ReconnectController.java
@@ -1,5 +1,6 @@
-package Gotcha.domain.ws;
+package Gotcha.domain.ws.controller;
 
+import Gotcha.domain.ws.api.ReconnectApi;
 import gotcha_domain.auth.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/ws")
 @RequiredArgsConstructor
-public class ReconnectController {
+public class ReconnectController implements ReconnectApi {
     private final DisconnectManager disconnectManager;
 
     @GetMapping("/reconnect")


### PR DESCRIPTION
# 사용자 소켓 연결 해제 후 대기방 자동 퇴장 및 재접속 로직 작성

## 📝 개요  

사용자 소켓 연결 해제 후 대기방 자동 퇴장 및 재접속 로직 작성

---

## ⚙️ 구현 내용  

소켓 연결이 끊어진 사용자를 자동으로 대기방에서 퇴장 처리하고 일정 시간 내 재접속 시 기존 대기방 정보를 알려주는 기능을 구현하였습니다.

소켓 연결 해제 이벤트가 발생하면, 사용자가 대기방에 속해 있을 경우 해당 유저에 대해 퇴장 예약을 Redis에 저장합니다. 
이때 Redis 키는 disconnect:room:{userUuid} 형식으로 저장되고 유효기간은 30초로 설정됩니다.

30초 내에 사용자가 재접속하면 클라이언트에서 /api/v1/ws/reconnect 엔드포인트로 요청을 보내 Redis에 저장된 roomId를 조회합니다. 
이 roomId를 바탕으로 프론트엔드는 사용자를 기존 방에 복귀시킬 수 있습니다.

반대로 30초가 지나면 Redis에 저장된 키가 만료되고 RedisKeyExpirationListener를 통해 해당 사용자가 속해 있던 방에서 자동으로 퇴장 처리됩니다. 
이 때 방장이 퇴장했을 경우에는 다음 사용자에게 방장 권한을 위임하거나 남은 인원이 없으면 방을 삭제하게 됩니다.

Redis의 만료 이벤트 감지를 위해 RedisMessageListenerContainer와 KeyExpirationEventMessageListener를 활용하여 키 만료 시점을 감지하고 퇴장 처리를 수행합니다.

이 기능의 흐름은 다음과 같이 구성됩니다:

1. 사용자가 소켓 연결 해제됨
2. WebSocketDisconnectListener가 트리거되고, 사용자의 방 ID를 조회하여 disconnect:room:{userUuid} 키를 Redis에 30초 동안 저장
3. 사용자가 30초 내 재접속할 경우 /api/v1/ws/reconnect 요청을 통해 해당 키를 조회하여 roomId 반환 (이후 프론트에서 방 복귀 처리)
4. 30초 경과 시 Redis 키 만료 → RedisKeyExpirationListener가 동작하여 자동 퇴장 처리

이 기능을 통해 일시적인 네트워크 불안정이나 새로고침 같은 상황에서도 사용자 경험을 보완할 수 있으며 장기 미접속자는 자동 퇴장 처리되어 대기방 정합성을 유지할 수 있게 됩니다.

---
