### PR TITLE
feat: 소켓 연결 해제 시 오프라인 알림 기능 추가

### DIFF
--- a/gotcha-common/src/main/java/gotcha_common/event/UserDisconnectedEvent.java
+++ b/gotcha-common/src/main/java/gotcha_common/event/UserDisconnectedEvent.java
@@ -1,0 +1,10 @@
+package gotcha_common.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserDisconnectedEvent {
+    private final String userUuid;
+}

--- a/gotcha-socket/src/main/java/socket_server/common/listener/WebSocketDisconnectListener.java
+++ b/gotcha-socket/src/main/java/socket_server/common/listener/WebSocketDisconnectListener.java
@@ -1,7 +1,9 @@
 package socket_server.common.listener;
 
+import gotcha_common.event.UserDisconnectedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -20,6 +22,7 @@ public class WebSocketDisconnectListener {
     private final RoomUserService roomUserService;
     private final DisconnectManager disconnectManager;
     private final GameEndService gameEndService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @EventListener
     public void onDisconnect(SessionDisconnectEvent event) {
@@ -43,6 +46,7 @@ public class WebSocketDisconnectListener {
                 gameEndService.handleDisconnectGame(roomId, userUuid);
             }
 
+            eventPublisher.publishEvent(new UserDisconnectedEvent(userUuid));
         }
 
     }

--- a/gotcha/src/main/java/Gotcha/domain/friend/config/FriendListenerConfig.java
+++ b/gotcha/src/main/java/Gotcha/domain/friend/config/FriendListenerConfig.java
@@ -1,0 +1,23 @@
+package Gotcha.domain.friend.config;
+
+import Gotcha.domain.friend.listener.FriendOfflineNotifier;
+import Gotcha.domain.friend.repository.FriendRepository;
+import gotcha_user.service.UserService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import socket_server.domain.friend.service.FriendSocketService;
+
+@Configuration
+public class FriendListenerConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(FriendOfflineNotifier.class)
+    public FriendOfflineNotifier friendOfflineNotifier(
+            UserService userService,
+            FriendRepository friendRepository,
+            FriendSocketService friendSocketService
+    ) {
+        return new FriendOfflineNotifier(userService, friendRepository, friendSocketService);
+    }
+}

--- a/gotcha/src/main/java/Gotcha/domain/friend/listener/FriendOfflineNotifier.java
+++ b/gotcha/src/main/java/Gotcha/domain/friend/listener/FriendOfflineNotifier.java
@@ -1,0 +1,38 @@
+package Gotcha.domain.friend.listener;
+
+import Gotcha.domain.friend.repository.FriendRepository;
+import gotcha_common.event.UserDisconnectedEvent;
+import gotcha_domain.user.User;
+import gotcha_user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import socket_server.domain.friend.dto.FriendEventType;
+import socket_server.domain.friend.service.FriendSocketService;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Slf4j
+public class FriendOfflineNotifier {
+    private final UserService userService;
+    private final FriendRepository friendRepository;
+    private final FriendSocketService friendSocketService;
+
+    @EventListener
+    public void handleUserDisconnected(UserDisconnectedEvent event) {
+        String userUuid = event.getUserUuid();
+
+        User user = userService.findUserByUuid(userUuid);
+        List<User> friends = friendRepository.findAllByUserId(user.getId()).stream()
+                .map(friend -> friend.getOther(user))
+                .distinct()
+                .toList();
+
+        for (User friend : friends) {
+            friendSocketService.sendFriendAlert(user.getUuid(), friend.getUuid(), user.getUuid(), FriendEventType.OFFLINE);
+        }
+
+        log.info("{}의 친구들에게 OFFLINE 알림 전송 완료", userUuid);
+    }
+}


### PR DESCRIPTION
# 소켓 연결 해제 시 오프라인 알림 기능 추가

## 📝 개요  

기존에 온라인 알림만 있었지만 오프라인 알림도 추가하였습니다.

---

## ⚙️ 구현 내용  

socket 모듈에서 처리하고 싶었지만 모듈의존성 문제로 인해 소켓 모듈에서는 이벤트를 발행하기만 하고,
메인 모듈에서 해당 이벤트를 처리하도록 하였습니다.

FriendOfflineNotifer 클래스에 @Component 어노테이션을 이용해서 등록을 했지만, 어째서인지 여러 모듈에서 중복으로 컴포넌트를 등록시켜서 FriendListenerConfig를 이용해서 한번만 등록되도록 하였습니다.

---

## 🧪 테스트 결과  

![image](https://github.com/user-attachments/assets/549dc168-717f-445d-be76-d6e56cd76950)

---
