### PR TITLE
fix: cpu 사용량 최적화를 위한 코드 수정

### DIFF
--- a/gotcha-socket/src/main/java/socket_server/domain/chat/service/ChatLogCleaner.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/service/ChatLogCleaner.java
@@ -1,12 +1,11 @@
 package socket_server.domain.chat.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import gotcha_domain.chat.ChatType;
 import socket_server.domain.room.repository.RoomRepository;
-
-import java.util.Set;
 
 @Component
 @Slf4j
@@ -22,16 +21,28 @@ public class ChatLogCleaner {
 
     @Scheduled(fixedRate = 60000)
     public void cleanExpiredChatLogs() {
+        // 1. 모든 채팅 로그 삭제
         chatLogService.removeExpiredMessages(ChatType.ALL, null);
 
-        Set<String> roomIds = roomRepository.getAllRoomIds();
-        for (String roomId : roomIds) {
-            chatLogService.removeExpiredMessages(ChatType.ROOM, roomId);
+        // 2. SSCAN을 이용해 대기방 채팅 로그 삭제
+        try (Cursor<String> roomKeys = roomRepository.scanRoomKeys()) {
+            while (roomKeys.hasNext()) {
+                String roomKey = roomKeys.next();
+                String roomId = roomKey.replaceFirst("room:", "");
+                chatLogService.removeExpiredMessages(ChatType.ROOM, roomId);
+            }
+        } catch (Exception e) {
+            log.error("대기방 채팅 로그 삭제 중 오류 발생", e);
         }
 
-        Set<String> privateKeys = chatLogService.getPrivateChatKeys();
-        for (String key : privateKeys) {
-            chatLogService.removeExpiredMessagesByKey(key);
+        // 3. SSCAN을 이용해 1대1 채팅 로그 삭제
+        try (Cursor<String> privateKeys = chatLogService.scanPrivateChatKeys()) {
+            while (privateKeys.hasNext()) {
+                String key = privateKeys.next();
+                chatLogService.removeExpiredMessagesByKey(key);
+            }
+        } catch (Exception e) {
+            log.error("1대1 채팅 로그 삭제 중 오류 발생", e);
         }
     }
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/service/ChatLogService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/service/ChatLogService.java
@@ -23,6 +23,7 @@ public class ChatLogService {
     private final RedisTemplate<String, String> redisTemplate;
     private final JsonSerializer jsonSerializer;
     private final ErrorType CHAT_ERROR = ErrorType.CHAT;
+    private static final String PRIVATE_CHAT_KEYS_INDEX = "chat:private:index"; // 인덱스 Set을 위한 키
 
     public ChatLogService(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate,
                           JsonSerializer jsonSerializer) {
@@ -44,6 +45,11 @@ public class ChatLogService {
         double score = Instant.now().toEpochMilli();
 
         redisTemplate.opsForZSet().add(key, serialized, score);
+
+        // PRIVATE 채팅일 경우, 키 인덱스 Set에 키를 추가
+        if (chatType == ChatType.PRIVATE) {
+            redisTemplate.opsForSet().add(PRIVATE_CHAT_KEYS_INDEX, key);
+        }
     }
 
     public void removeExpiredMessages(ChatType chatType, String identifier) {
@@ -98,7 +104,8 @@ public class ChatLogService {
 
 
     public Set<String> getPrivateChatKeys() {
-        Set<String> keys = redisTemplate.keys("chat:private:*:*:log");
+        // KEYS 대신 SMEMBERS를 사용하여 안전하고 빠르게 키 목록을 가져옴
+        Set<String> keys = redisTemplate.opsForSet().members(PRIVATE_CHAT_KEYS_INDEX);
         return keys != null ? keys : Set.of();
     }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/service/ChatLogService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/service/ChatLogService.java
@@ -1,7 +1,9 @@
 package socket_server.domain.chat.service;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Service;
 import socket_server.common.exception.ErrorType;
 import socket_server.common.util.JsonSerializer;
@@ -102,7 +104,15 @@ public class ChatLogService {
                 .collect(Collectors.toList());
     }
 
+    public Cursor<String> scanPrivateChatKeys() {
+        ScanOptions options = ScanOptions.scanOptions().count(1000).build();
+        return redisTemplate.opsForSet().scan(PRIVATE_CHAT_KEYS_INDEX, options);
+    }
 
+    /**
+     * @deprecated Redis에 저장된 데이터의 양이 많아지면 SMEMBERS보다 SSCAN을 이용해 순차적으로 데이터를 받아오는게 더 효율적이라 SSCAN 방식으로 변경함
+     */
+    @Deprecated
     public Set<String> getPrivateChatKeys() {
         // KEYS 대신 SMEMBERS를 사용하여 안전하고 빠르게 키 목록을 가져옴
         Set<String> keys = redisTemplate.opsForSet().members(PRIVATE_CHAT_KEYS_INDEX);

--- a/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomRepository.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomRepository.java
@@ -1,7 +1,9 @@
 package socket_server.domain.room.repository;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
@@ -37,7 +39,21 @@ public class RoomRepository {
         redisTemplate.delete(getRoomKey(roomId));
     }
 
-    public Set<String> getAllRoomIds() {
+    /**
+     * SCAN 명령을 사용하여 서버를 블로킹하지 않고 안전하게 room 키들을 순회합니다.
+     * @return room 키들(예: "room:1234")을 순회할 수 있는 Cursor 객체
+     */
+    public Cursor<String> scanRoomKeys() {
+        ScanOptions options = ScanOptions.scanOptions().match("room:*").count(1000).build();
+        return redisTemplate.scan(options);
+    }
+
+    /**
+     * @deprecated 이 메서드는 KEYS 명령을 사용하므로 운영 환경에서는 적합하지 않음
+     * 대신 scanRoomKeys() 메서드 사용
+     */
+    @Deprecated
+    private Set<String> getAllRoomIds() {
         Set<String> keys = redisTemplate.keys("room:*");
         if (keys == null) return Set.of();
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -6,6 +6,7 @@ import gotcha_domain.chat.ChatMessage;
 import gotcha_domain.chat.ChatType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import socket_server.common.config.RedisMessage;
@@ -30,12 +31,11 @@ import socket_server.domain.room.repository.RoomRepository;
 import socket_server.domain.room.repository.RoomUserRepository;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import static socket_server.common.constants.WebSocketConstants.ROOM_PREFIX;
 
@@ -184,29 +184,31 @@ public class RoomService {
     }
 
     public List<RoomSummaryRes> getAllRoomSummaries(RoomListReq roomListReq) {
-        Set<String> allRoomIds = roomRepository.getAllRoomIds();
+        List<RoomSummaryRes> summaries = new ArrayList<>();
+        try (Cursor<String> roomKeys = roomRepository.scanRoomKeys()) {
+            while (roomKeys.hasNext()) {
+                String roomKey = roomKeys.next();
+                String roomId = roomKey.replaceFirst("room:", "");
 
-        return allRoomIds.stream()
-                .map(roomId -> {
-                    Map<Object, Object> roomData = roomRepository.getRoomData(roomId);
-                    if (roomData == null || roomData.isEmpty()) {
-                        return null;
-                    }
+                Map<Object, Object> roomData = roomRepository.getRoomData(roomId);
+                if (roomData == null || roomData.isEmpty()) {
+                    continue;
+                }
 
-                    RoomMetadata metadata = RoomMetadata.fromRedisMap(roomId, roomData);
+                RoomMetadata metadata = RoomMetadata.fromRedisMap(roomId, roomData);
 
-                    if (!metadata.getGameType().equals(roomListReq.gameType())) {
-                        return null;
-                    }
-                    if (roomListReq.difficulty() != null && !roomListReq.difficulty().equals(metadata.getDifficulty())) {
-                        return null;
-                    }
+                if (!metadata.getGameType().equals(roomListReq.gameType())) {
+                    continue;
+                }
+                if (roomListReq.difficulty() != null && !roomListReq.difficulty().equals(metadata.getDifficulty())) {
+                    continue;
+                }
 
-                    int currentUser = roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR).size();
-                    return RoomSummaryRes.of(metadata, currentUser);
-                })
-                .filter(Objects::nonNull)
-                .toList();
+                int currentUser = roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR).size();
+                summaries.add(RoomSummaryRes.of(metadata, currentUser));
+            }
+        }
+        return summaries;
     }
 
 

--- a/gotcha-user/src/main/java/gotcha_ranking/util/RankingInitializer.java
+++ b/gotcha-user/src/main/java/gotcha_ranking/util/RankingInitializer.java
@@ -4,9 +4,10 @@ import gotcha_ranking.service.RankingRedisService;
 import gotcha_domain.user.User;
 import gotcha_user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,13 +15,19 @@ public class RankingInitializer {
 
     private final UserRepository userRepository;
     private final RankingRedisService rankingRedisService;
+    private static final int PAGE_SIZE = 100; // 한 번에 처리할 사용자 수
 
     public void initializeRanking() {
-        List<User> users = userRepository.findAll();
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+        Page<User> userPage;
 
-        for (User user : users) {
-            rankingRedisService.updateUserExpRanking(user.getId(), user.getExp());
-        }
+        do {
+            userPage = userRepository.findAll(pageable);
+            for (User user : userPage.getContent()) {
+                rankingRedisService.updateUserExpRanking(user.getId(), user.getExp());
+            }
+
+            pageable = userPage.nextPageable();
+        } while (userPage.hasNext());
     }
-
 }

--- a/gotcha/src/main/java/Gotcha/domain/friend/repository/FriendRepository.java
+++ b/gotcha/src/main/java/Gotcha/domain/friend/repository/FriendRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface FriendRepository extends JpaRepository<Friend, Long> {
     @Query("""
                 SELECT f FROM Friend f
+                JOIN FETCH f.user1
+                JOIN FETCH f.user2
                 WHERE f.user1.id = :userId OR f.user2.id = :userId
             """)
     List<Friend> findAllByUserId(@Param("userId") Long userId);


### PR DESCRIPTION
# fix: cpu 사용량 최적화를 위한 코드 수정

## 📝 개요  

fix: cpu 사용량 최적화를 위한 코드 수정

---

## ⚙️ 구현 내용  

기존에 채팅 로그를 관리하는 과정에서 레디스의 모든 키를 확인하면서 채팅 로그와 관련된 키를 선택하는 과정이 있었는데
해당 과정에서 레디스에 무리를 주게되고, cpu에 부담이 갈수도 있겠다는 생각에 모든 키를 보는 것이 아닌, 레디스에 채팅 로그 키에 대한 Set을 추가하여 해당 키만 탐색해 한번에 모든 채팅 로그들을 가져올 수 있도록 하였습니다.

또한, 부가적으로 서버의 시작과 동시에 랭킹을 초기화 하는 과정에서 userRepository.findAll을 사용하여 현재는 문제가 없지만 사용자가 많아진다면 이것도 cpu에 문제가 갈 것 같다고 생각해 페이지를 사용하여 조금씩 랭킹을 업데이트 해주는 방향으로 수정하였습니다.

---

## 📎 기타

일단 코드 변경 사항을 적용하고 서버의 상황을 좀 더 지켜봐야할 것 같습니다.

---

