### PR TITLE
feat: 채팅 설정에 따른 채팅 필터링 구현

### DIFF
--- a/gotcha-common/src/main/java/gotcha_common/util/RedisUtil.java
+++ b/gotcha-common/src/main/java/gotcha_common/util/RedisUtil.java
@@ -35,4 +35,24 @@ public class RedisUtil {
     public Long getExpire(String key, TimeUnit timeUnit) {
         return redisTemplate.getExpire(key, timeUnit);
     }
+
+    public void addSetValue(String key, String... values) {
+        redisTemplate.opsForSet().add(key, values);
+    }
+
+    public void removeSetValue(String key, Object... values) {
+        redisTemplate.opsForSet().remove(key, values);
+    }
+
+    public Boolean isSetMember(String key, String value) {
+        return redisTemplate.opsForSet().isMember(key, value);
+    }
+
+    public void hSet(String key, String field, Object value) {
+        redisTemplate.opsForHash().put(key, field, value);
+    }
+
+    public Object hGet(String key, String field) {
+        return redisTemplate.opsForHash().get(key, field);
+    }
 }

--- a/gotcha-domain/src/main/java/gotcha_domain/user/MessageType.java
+++ b/gotcha-domain/src/main/java/gotcha_domain/user/MessageType.java
@@ -1,0 +1,6 @@
+package gotcha_domain.user;
+
+public enum MessageType {
+    PUBLIC, // 전체 채팅
+    PRIVATE // 귓속말
+}

--- a/gotcha-domain/src/main/java/gotcha_domain/user/User.java
+++ b/gotcha-domain/src/main/java/gotcha_domain/user/User.java
@@ -27,8 +27,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -78,47 +78,47 @@ public class User extends BaseTimeEntity {
 
     @JsonIgnore
     @OneToMany(mappedBy = "player")
-    private List<UserGameHistory> userGameHistories = new ArrayList<>();
+    private Set<UserGameHistory> userGameHistories = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "writer")
-    private List<Answer> answers = new ArrayList<>();
+    private Set<Answer> answers = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "writer")
-    private List<Inquiry> inquiries = new ArrayList<>();
+    private Set<Inquiry> inquiries = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "writer")
-    private List<Notification> notifications = new ArrayList<>();
+    private Set<Notification> notifications = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "user")
-    private List<UserReport> userReports = new ArrayList<>();
+    private Set<UserReport> userReports = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "user")
-    private List<UserAchievement> userAchievements = new ArrayList<>();
+    private Set<UserAchievement> userAchievements = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "user1")
-    private List<Friend> friends = new ArrayList<>();
+    private Set<Friend> friends = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "user2")
-    private List<Friend> friendOf = new ArrayList<>();
+    private Set<Friend> friendOf = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "fromUser")
-    private List<FriendRequest> sentFriendRequests = new ArrayList<>();
+    private Set<FriendRequest> sentFriendRequests = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "toUser")
-    private List<FriendRequest> receivedFriendRequests = new ArrayList<>();
+    private Set<FriendRequest> receivedFriendRequests = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "user")
-    private List<BugReport> bugReports = new ArrayList<>();
+    private Set<BugReport> bugReports = new HashSet<>();
 
     @Builder
     public User(Long id, String email, String password, String nickname, Role role, String uuid){
@@ -134,8 +134,35 @@ public class User extends BaseTimeEntity {
         this.nickname = newNickname;
     }
 
+    public boolean isFriendWith(User user) {
+        // 친구 목록(friends, friendOf)을 확인하여 친구 여부 반환
+        return this.friends.stream().anyMatch(f -> f.getUser2().equals(user)) ||
+               this.friendOf.stream().anyMatch(f -> f.getUser1().equals(user));
+    }
+
+    public boolean canReceiveMessage(MessageType messageType, User sender) {
+        if (this.equals(sender)) return true; // 자신은 항상 수신
+        if (this.chatOption == ChatOption.DENY_ALL) return false;
+        if (this.chatOption == ChatOption.FRIENDS_ONLY && !isFriendWith(sender)) return false;
+        if (messageType == MessageType.PRIVATE && (this.privateChatOption == PrivateChatOption.DENY || !isFriendWith(sender))) return false;
+        return true;
+    }
+
     public void updateChatSettings(ChatOption chatOption, PrivateChatOption privateChatOption) {
         this.chatOption = chatOption;
         this.privateChatOption = privateChatOption;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return id != null && id.equals(user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
     }
 }

--- a/gotcha-domain/src/main/java/gotcha_domain/user/User.java
+++ b/gotcha-domain/src/main/java/gotcha_domain/user/User.java
@@ -149,6 +149,6 @@ public class User extends BaseTimeEntity {
 
     @Override
     public int hashCode() {
-        return getClass().hashCode();
+        return (id != null) ? id.hashCode() : 0;
     }
 }

--- a/gotcha-domain/src/main/java/gotcha_domain/user/User.java
+++ b/gotcha-domain/src/main/java/gotcha_domain/user/User.java
@@ -134,20 +134,6 @@ public class User extends BaseTimeEntity {
         this.nickname = newNickname;
     }
 
-    public boolean isFriendWith(User user) {
-        // 친구 목록(friends, friendOf)을 확인하여 친구 여부 반환
-        return this.friends.stream().anyMatch(f -> f.getUser2().equals(user)) ||
-               this.friendOf.stream().anyMatch(f -> f.getUser1().equals(user));
-    }
-
-    public boolean canReceiveMessage(MessageType messageType, User sender) {
-        if (this.equals(sender)) return true; // 자신은 항상 수신
-        if (this.chatOption == ChatOption.DENY_ALL) return false;
-        if (this.chatOption == ChatOption.FRIENDS_ONLY && !isFriendWith(sender)) return false;
-        if (messageType == MessageType.PRIVATE && (this.privateChatOption == PrivateChatOption.DENY || !isFriendWith(sender))) return false;
-        return true;
-    }
-
     public void updateChatSettings(ChatOption chatOption, PrivateChatOption privateChatOption) {
         this.chatOption = chatOption;
         this.privateChatOption = privateChatOption;

--- a/gotcha-socket/src/main/java/socket_server/common/config/RedisIntegrationConfig.java
+++ b/gotcha-socket/src/main/java/socket_server/common/config/RedisIntegrationConfig.java
@@ -26,6 +26,7 @@ import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import socket_server.common.exception.ErrorType;
 import socket_server.common.util.JsonSerializer;
+import socket_server.domain.chat.handler.ChattingPubSubHandler;
 import socket_server.domain.friend.handler.FriendPubSubHandler;
 import socket_server.domain.game.handler.GamePubSubHandler;
 import socket_server.domain.lobby.handler.LobbyPubSubHandler;
@@ -43,12 +44,14 @@ public class RedisIntegrationConfig {
     private final GamePubSubHandler gamePubSubHandler;
     private final LobbyPubSubHandler lobbyPubSubHandler;
     private final FriendPubSubHandler friendPubSubHandler;
+    private final ChattingPubSubHandler chattingPubSubHandler;
 
-    public RedisIntegrationConfig(RoomPubSubHandler roomHandler, GamePubSubHandler gamePubSubHandler, LobbyPubSubHandler lobbyPubSubHandler, FriendPubSubHandler friendPubSubHandler) {
+    public RedisIntegrationConfig(RoomPubSubHandler roomHandler, GamePubSubHandler gamePubSubHandler, LobbyPubSubHandler lobbyPubSubHandler, FriendPubSubHandler friendPubSubHandler, ChattingPubSubHandler chattingPubSubHandler) {
         this.roomHandler = roomHandler;
         this.gamePubSubHandler = gamePubSubHandler;
         this.lobbyPubSubHandler = lobbyPubSubHandler;
         this.friendPubSubHandler = friendPubSubHandler;
+        this.chattingPubSubHandler = chattingPubSubHandler;
     }
 
     @Bean("redisExecutor")
@@ -159,20 +162,13 @@ public class RedisIntegrationConfig {
     }
 
     @Bean
-    public IntegrationFlow chatMessageFlow(SimpMessagingTemplate template) {
-        ObjectMapper mapper = new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
+    public IntegrationFlow chatMessageFlow(JsonSerializer jsonSerializer) {
         return IntegrationFlow.from("chatMessageChannel")
-                .handle((payload, headers) -> {
-                    RedisMessage redisMessage = mapper.convertValue(payload, RedisMessage.class);
-
+                .handle((msg, headers) -> {
+                    RedisMessage redisMessage = jsonSerializer.deserialize(msg, RedisMessage.class, ErrorType.CHAT);
                     log.info("💬 [채팅 메시지] topic={}, user={}, payload={}",
                             redisMessage.topic(), redisMessage.userId(), redisMessage.payload());
-
-                    template.convertAndSend(redisMessage.topic(), redisMessage.payload());
-
+                    chattingPubSubHandler.onMessage(redisMessage.topic(), redisMessage);
                     return null;
                 }).get();
     }

--- a/gotcha-socket/src/main/java/socket_server/common/config/RedisIntegrationConfig.java
+++ b/gotcha-socket/src/main/java/socket_server/common/config/RedisIntegrationConfig.java
@@ -1,8 +1,6 @@
 package socket_server.common.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import gotcha_common.exception.CustomException;
 import gotcha_common.exception.ExceptionRes;
 import gotcha_common.exception.exceptionCode.GlobalExceptionCode;

--- a/gotcha-socket/src/main/java/socket_server/common/exception/chat/ChatExceptionCode.java
+++ b/gotcha-socket/src/main/java/socket_server/common/exception/chat/ChatExceptionCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum ChatExceptionCode implements ExceptionCode {
-    GUEST_CANNOT_CHAT(HttpStatus.FORBIDDEN, "CHAT_403_001", "게스트는 채팅을 보낼 수 없습니다.");
+    GUEST_CANNOT_CHAT(HttpStatus.FORBIDDEN, "CHAT_403_001", "게스트는 채팅을 보낼 수 없습니다."),
+    RECIPIENT_DENIED_PRIVATE_CHAT(HttpStatus.FORBIDDEN, "CHAT_403_002", "상대방이 귓속말 수신을 거부했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/gotcha-socket/src/main/java/socket_server/common/util/ChatPermissionUtil.java
+++ b/gotcha-socket/src/main/java/socket_server/common/util/ChatPermissionUtil.java
@@ -1,0 +1,35 @@
+package socket_server.common.util;
+
+import gotcha_domain.chat.ChatType;
+import gotcha_domain.user.ChatOption;
+import gotcha_domain.user.PrivateChatOption;
+
+public final class ChatPermissionUtil {
+
+    public ChatPermissionUtil() {};
+
+    public static boolean canReceiveMessageFromCache(
+            ChatOption chatOption,
+            PrivateChatOption privateChatOption,
+            boolean isFriend,
+            ChatType chatType
+    ) {
+        //전체 차단 설정이면 무조건 불가
+        if (chatOption == ChatOption.DENY_ALL) {
+            return false;
+        }
+
+        //친구만 허용인데 친구가 아니면 불가
+        if (chatOption == ChatOption.FRIENDS_ONLY && !isFriend) {
+            return false;
+        }
+
+        //귓속말 차단 여부
+        if (chatType == ChatType.PRIVATE && privateChatOption == PrivateChatOption.DENY) {
+            return false;
+        }
+
+        //위 조건을 모두 통과하면 수신 가능
+        return true;
+    }
+}

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/controller/ChattingController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/controller/ChattingController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import gotcha_domain.auth.SecurityUserDetails;
 import gotcha_domain.chat.ChatMessage;
 import gotcha_domain.chat.ChatType;
+import gotcha_domain.user.MessageType;
 import gotcha_domain.user.Role;
 import gotcha_domain.user.User;
 import gotcha_user.service.UserService;
@@ -73,7 +74,14 @@ public class ChattingController {
     @MessageMapping("/private")
     public void sendPrivateMessage(@Payload ChatMessageReq messageReq, @AuthenticationPrincipal SecurityUserDetails userDetails) throws JsonProcessingException {
         validateChatPermission(userDetails);
-        User receiver = userService.findUserByNickname(messageReq.receiverNickname());
+        User sender = userService.findUserByUuidWithFriends(userDetails.getUuid()); // 발신자 정보 조회 (친구 포함)
+        User receiver = userService.findUserByNicknameWithFriends(messageReq.receiverNickname()); // 수신자 정보 조회 (친구 포함)
+
+        // 수신자 채팅 옵션 확인 로직 추가
+        if (!receiver.canReceiveMessage(MessageType.PRIVATE, sender)) {
+            throw new SocketCustomException(CHAT_ERROR, ChatExceptionCode.RECIPIENT_DENIED_PRIVATE_CHAT);
+        }
+
         String receiverUuid = receiver.getUuid();
 
         ChatMessage message = new ChatMessage(

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/controller/ChattingController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/controller/ChattingController.java
@@ -20,6 +20,7 @@ import socket_server.common.config.RedisMessage;
 import socket_server.common.exception.ErrorType;
 import socket_server.common.exception.SocketCustomException;
 import socket_server.common.exception.chat.ChatExceptionCode;
+import socket_server.common.util.ChatPermissionUtil;
 import socket_server.common.util.JsonSerializer;
 import socket_server.domain.chat.dto.ChatMessageReq;
 import socket_server.domain.chat.service.ChatLogService;
@@ -91,16 +92,19 @@ public class ChattingController {
         ChatOption chatOption = (chatOptionStr != null) ? ChatOption.valueOf(chatOptionStr) : ChatOption.ALLOW_ALL;
         PrivateChatOption privateChatOption = (privateChatOptionStr != null) ? PrivateChatOption.valueOf(privateChatOptionStr) : PrivateChatOption.ALLOW;
 
-        if (chatOption == ChatOption.DENY_ALL || privateChatOption == PrivateChatOption.DENY) {
+        boolean isFriend = redisUtil.isSetMember("user:" + receiverUuid + ":friends", senderUuid);
+
+        boolean canReceive = ChatPermissionUtil.canReceiveMessageFromCache(
+                chatOption,
+                privateChatOption,
+                isFriend,
+                ChatType.PRIVATE
+        );
+
+        if (!canReceive) {
             throw new SocketCustomException(CHAT_ERROR, ChatExceptionCode.RECIPIENT_DENIED_PRIVATE_CHAT);
         }
 
-        if (chatOption == ChatOption.FRIENDS_ONLY) {
-            String friendCacheKey = "user:" + receiverUuid + ":friends";
-            if (!redisUtil.isSetMember(friendCacheKey, senderUuid)) {
-                throw new SocketCustomException(CHAT_ERROR, ChatExceptionCode.RECIPIENT_DENIED_PRIVATE_CHAT);
-            }
-        }
 
         ChatMessage message = new ChatMessage(
                 userDetails.getNickname(),

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/controller/ChattingController.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/controller/ChattingController.java
@@ -1,10 +1,12 @@
 package socket_server.domain.chat.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import gotcha_common.util.RedisUtil;
 import gotcha_domain.auth.SecurityUserDetails;
 import gotcha_domain.chat.ChatMessage;
 import gotcha_domain.chat.ChatType;
-import gotcha_domain.user.MessageType;
+import gotcha_domain.user.ChatOption;
+import gotcha_domain.user.PrivateChatOption;
 import gotcha_domain.user.Role;
 import gotcha_domain.user.User;
 import gotcha_user.service.UserService;
@@ -35,16 +37,19 @@ public class ChattingController {
     private final JsonSerializer jsonSerializer;
     private final ChatLogService chatLogService;
     private final UserService userService;
+    private final RedisUtil redisUtil;
     private final ErrorType CHAT_ERROR = ErrorType.CHAT;
 
     public ChattingController(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate,
                               JsonSerializer jsonSerializer,
                               ChatLogService chatLogService,
-                              UserService userService) {
+                              UserService userService,
+                              RedisUtil redisUtil) {
         this.redisTemplate = redisTemplate;
         this.jsonSerializer = jsonSerializer;
         this.chatLogService = chatLogService;
         this.userService = userService;
+        this.redisUtil = redisUtil;
     }
 
     // 1. 전체 채팅방 메시지 전송
@@ -74,15 +79,28 @@ public class ChattingController {
     @MessageMapping("/private")
     public void sendPrivateMessage(@Payload ChatMessageReq messageReq, @AuthenticationPrincipal SecurityUserDetails userDetails) throws JsonProcessingException {
         validateChatPermission(userDetails);
-        User sender = userService.findUserByUuidWithFriends(userDetails.getUuid()); // 발신자 정보 조회 (친구 포함)
-        User receiver = userService.findUserByNicknameWithFriends(messageReq.receiverNickname()); // 수신자 정보 조회 (친구 포함)
 
-        // 수신자 채팅 옵션 확인 로직 추가
-        if (!receiver.canReceiveMessage(MessageType.PRIVATE, sender)) {
+        User receiver = userService.findUserByNickname(messageReq.receiverNickname());
+        String receiverUuid = receiver.getUuid();
+        String senderUuid = userDetails.getUuid();
+
+        String settingsCacheKey = "user:" + receiverUuid + ":settings";
+        String chatOptionStr = (String) redisUtil.hGet(settingsCacheKey, "chatOption");
+        String privateChatOptionStr = (String) redisUtil.hGet(settingsCacheKey, "privateChatOption");
+
+        ChatOption chatOption = (chatOptionStr != null) ? ChatOption.valueOf(chatOptionStr) : ChatOption.ALLOW_ALL;
+        PrivateChatOption privateChatOption = (privateChatOptionStr != null) ? PrivateChatOption.valueOf(privateChatOptionStr) : PrivateChatOption.ALLOW;
+
+        if (chatOption == ChatOption.DENY_ALL || privateChatOption == PrivateChatOption.DENY) {
             throw new SocketCustomException(CHAT_ERROR, ChatExceptionCode.RECIPIENT_DENIED_PRIVATE_CHAT);
         }
 
-        String receiverUuid = receiver.getUuid();
+        if (chatOption == ChatOption.FRIENDS_ONLY) {
+            String friendCacheKey = "user:" + receiverUuid + ":friends";
+            if (!redisUtil.isSetMember(friendCacheKey, senderUuid)) {
+                throw new SocketCustomException(CHAT_ERROR, ChatExceptionCode.RECIPIENT_DENIED_PRIVATE_CHAT);
+            }
+        }
 
         ChatMessage message = new ChatMessage(
                 userDetails.getNickname(),
@@ -99,7 +117,7 @@ public class ChattingController {
 
         redisTemplate.convertAndSend(CHAT_PRIVATE_CHANNEL + receiverUuid, jsonSerializer.serialize(redisMessage, ErrorType.CHAT));
 
-        chatLogService.saveChatMessage(ChatType.PRIVATE, receiverUuid, message, userDetails.getUuid() );
+        chatLogService.saveChatMessage(ChatType.PRIVATE, receiverUuid, message, userDetails.getUuid());
     }
 
     private void validateChatPermission(SecurityUserDetails userDetails) {

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/handler/ChattingPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/handler/ChattingPubSubHandler.java
@@ -2,7 +2,9 @@ package socket_server.domain.chat.handler;
 
 import gotcha_common.util.RedisUtil;
 import gotcha_domain.chat.ChatMessage;
+import gotcha_domain.chat.ChatType;
 import gotcha_domain.user.ChatOption;
+import gotcha_domain.user.PrivateChatOption;
 import gotcha_domain.user.User;
 import gotcha_user.service.UserService;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 import socket_server.common.config.RedisMessage;
 import socket_server.common.exception.ErrorType;
 import socket_server.common.listener.PubSubHandler;
+import socket_server.common.util.ChatPermissionUtil;
 import socket_server.common.util.JsonSerializer;
 
 import static socket_server.common.constants.WebSocketConstants.CHAT_ALL_CHANNEL;
@@ -74,20 +77,17 @@ public class ChattingPubSubHandler extends PubSubHandler {
                 String chatOptionStr = (String) redisUtil.hGet(settingsCacheKey, "chatOption");
                 ChatOption chatOption = (chatOptionStr != null) ? ChatOption.valueOf(chatOptionStr) : ChatOption.ALLOW_ALL; // Default to ALLOW_ALL if not cached
 
-                // 1. DENY_ALL 인지 확인
-                if (chatOption == ChatOption.DENY_ALL) {
-                    continue;
-                }
+                boolean isFriend = redisUtil.isSetMember("user:" + recipientUuid + ":friends", senderUuid);
 
-                // 2. FRIENDS_ONLY 인지 확인
-                if (chatOption == ChatOption.FRIENDS_ONLY) {
-                    String friendCacheKey = "user:" + recipientUuid + ":friends";
-                    if (!redisUtil.isSetMember(friendCacheKey, senderUuid)) {
-                        continue;
-                    }
-                }
+                boolean canReceive = ChatPermissionUtil.canReceiveMessageFromCache(
+                        chatOption,
+                        PrivateChatOption.ALLOW, // 전체 채팅에는 귓속말 설정 무의미하므로 기본값
+                        isFriend,
+                        ChatType.ALL
+                );
 
-                // All 은 확인하지 않고 메시지 전송
+                if (!canReceive) continue;
+
                 messagingTemplate.convertAndSendToUser(
                         recipientUuid,
                         "/queue/chat",

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/handler/ChattingPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/handler/ChattingPubSubHandler.java
@@ -1,7 +1,8 @@
 package socket_server.domain.chat.handler;
 
+import gotcha_common.util.RedisUtil;
 import gotcha_domain.chat.ChatMessage;
-import gotcha_domain.user.MessageType;
+import gotcha_domain.user.ChatOption;
 import gotcha_domain.user.User;
 import gotcha_user.service.UserService;
 import lombok.extern.slf4j.Slf4j;
@@ -15,8 +16,6 @@ import socket_server.common.exception.ErrorType;
 import socket_server.common.listener.PubSubHandler;
 import socket_server.common.util.JsonSerializer;
 
-import java.util.Set;
-
 import static socket_server.common.constants.WebSocketConstants.CHAT_ALL_CHANNEL;
 import static socket_server.common.constants.WebSocketConstants.CHAT_PRIVATE_CHANNEL;
 import static socket_server.common.constants.WebSocketConstants.CHAT_ROOM_CHANNEL;
@@ -27,14 +26,17 @@ import static socket_server.common.constants.WebSocketConstants.CHAT_ROOM_CHANNE
 public class ChattingPubSubHandler extends PubSubHandler {
     private final SimpUserRegistry userRegistry;
     private final UserService userService;
+    private final RedisUtil redisUtil;
 
     public ChattingPubSubHandler(SimpMessagingTemplate messagingTemplate,
                                  JsonSerializer jsonSerializer,
                                  SimpUserRegistry userRegistry,
-                                 UserService userService) {
+                                 UserService userService,
+                                 RedisUtil redisUtil) {
         super(messagingTemplate, jsonSerializer);
         this.userRegistry = userRegistry;
         this.userService = userService;
+        this.redisUtil = redisUtil;
     }
 
     @Override
@@ -61,23 +63,39 @@ public class ChattingPubSubHandler extends PubSubHandler {
         ChatMessage chatMessage = jsonSerializer.deserialize(redisMessage.payload(), ChatMessage.class, ErrorType.CHAT);
         User sender = userService.findUserByNickname(chatMessage.nickname());
 
-        Set<SimpUser> users = userRegistry.getUsers();
-        // 현재 접속 중인 모든 유저를 대상으로 필터링
-        for (SimpUser simpUser : users) {
-            User recipient = userService.findUserByUuidWithFriends(simpUser.getName());
-            if (recipient == null) {
-                log.warn("UUID로 사용자를 찾을 수 없습니다: {}", simpUser.getName());
-                continue;
-            }
+        String senderUuid = sender.getUuid();
 
-            boolean canReceive = recipient.canReceiveMessage(MessageType.PUBLIC, sender);
+        for (SimpUser simpUser : userRegistry.getUsers()) {
+            String recipientUuid = simpUser.getName();
+            if (recipientUuid.equals(senderUuid)) continue;
 
-            if (canReceive) {
+            try {
+                String settingsCacheKey = "user:" + recipientUuid + ":settings";
+                String chatOptionStr = (String) redisUtil.hGet(settingsCacheKey, "chatOption");
+                ChatOption chatOption = (chatOptionStr != null) ? ChatOption.valueOf(chatOptionStr) : ChatOption.ALLOW_ALL; // Default to ALLOW_ALL if not cached
+
+                // 1. DENY_ALL 인지 확인
+                if (chatOption == ChatOption.DENY_ALL) {
+                    continue;
+                }
+
+                // 2. FRIENDS_ONLY 인지 확인
+                if (chatOption == ChatOption.FRIENDS_ONLY) {
+                    String friendCacheKey = "user:" + recipientUuid + ":friends";
+                    if (!redisUtil.isSetMember(friendCacheKey, senderUuid)) {
+                        continue;
+                    }
+                }
+
+                // All 은 확인하지 않고 메시지 전송
                 messagingTemplate.convertAndSendToUser(
-                        recipient.getUuid(),
-                        "/queue/chat",       // 전체 채팅은 사용자별 필터링을 위해 개별 전송
+                        recipientUuid,
+                        "/queue/chat",
                         chatMessage
                 );
+
+            } catch (Exception e) {
+                log.error("handleAllChat 처리 중 특정 사용자에게 에러 발생: {}", recipientUuid, e);
             }
         }
     }

--- a/gotcha-socket/src/main/java/socket_server/domain/chat/handler/ChattingPubSubHandler.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/chat/handler/ChattingPubSubHandler.java
@@ -1,36 +1,97 @@
 package socket_server.domain.chat.handler;
 
+import gotcha_domain.chat.ChatMessage;
+import gotcha_domain.user.MessageType;
+import gotcha_domain.user.User;
+import gotcha_user.service.UserService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.stereotype.Service;
+import socket_server.common.config.RedisMessage;
+import socket_server.common.exception.ErrorType;
 import socket_server.common.listener.PubSubHandler;
 import socket_server.common.util.JsonSerializer;
 
-import static socket_server.common.constants.WebSocketConstants.*;
+import java.util.Set;
 
+import static socket_server.common.constants.WebSocketConstants.CHAT_ALL_CHANNEL;
+import static socket_server.common.constants.WebSocketConstants.CHAT_PRIVATE_CHANNEL;
+import static socket_server.common.constants.WebSocketConstants.CHAT_ROOM_CHANNEL;
+
+@Slf4j
 @Service
 @Qualifier("chattingPubSubHandler")
 public class ChattingPubSubHandler extends PubSubHandler {
+    private final SimpUserRegistry userRegistry;
+    private final UserService userService;
 
-    public ChattingPubSubHandler(SimpMessagingTemplate messagingTemplate, JsonSerializer jsonSerializer) {
+    public ChattingPubSubHandler(SimpMessagingTemplate messagingTemplate,
+                                 JsonSerializer jsonSerializer,
+                                 SimpUserRegistry userRegistry,
+                                 UserService userService) {
         super(messagingTemplate, jsonSerializer);
+        this.userRegistry = userRegistry;
+        this.userService = userService;
     }
 
     @Override
     protected void initHandlers() {
-        handlers.put(CHAT_ALL_CHANNEL, (channel, message) -> handleAllChat(message));
-        handlers.put(CHAT_PRIVATE_CHANNEL, this:: handlePrivateChat);
-        handlers.put(CHAT_ROOM_CHANNEL, this:: handleRoomChat);
+        handlers.put(CHAT_ALL_CHANNEL, (channel, message) -> {
+            try {
+                handleAllChat(message);
+            } catch (Exception e) {
+                log.error("[ChattingPubSubHandler] handleAllChat 처리 중 에러 발생", e);
+            }
+        });
+        handlers.put(CHAT_PRIVATE_CHANNEL, (channel, message) -> {
+            try {
+                handlePrivateChat(channel, message);
+            } catch (Exception e) {
+                log.error("[ChattingPubSubHandler] handlePrivateChat 처리 중 에러 발생 - 채널:{}", channel, e);
+            }
+        });
+        handlers.put(CHAT_ROOM_CHANNEL, this::handleRoomChat);
     }
 
-    // 채팅 처리 메소드
-    private void handleAllChat( Object object) {
+    private void handleAllChat(Object object) {
+        RedisMessage redisMessage = (RedisMessage) object;
+        ChatMessage chatMessage = jsonSerializer.deserialize(redisMessage.payload(), ChatMessage.class, ErrorType.CHAT);
+        User sender = userService.findUserByNickname(chatMessage.nickname());
 
+        Set<SimpUser> users = userRegistry.getUsers();
+        // 현재 접속 중인 모든 유저를 대상으로 필터링
+        for (SimpUser simpUser : users) {
+            User recipient = userService.findUserByUuidWithFriends(simpUser.getName());
+            if (recipient == null) {
+                log.warn("UUID로 사용자를 찾을 수 없습니다: {}", simpUser.getName());
+                continue;
+            }
+
+            boolean canReceive = recipient.canReceiveMessage(MessageType.PUBLIC, sender);
+
+            if (canReceive) {
+                messagingTemplate.convertAndSendToUser(
+                        recipient.getUuid(),
+                        "/queue/chat",       // 전체 채팅은 사용자별 필터링을 위해 개별 전송
+                        chatMessage
+                );
+            }
+        }
     }
 
-    private void handlePrivateChat(String channel,  Object object) {
+    private void handlePrivateChat(String channel, Object object) {
+        RedisMessage redisMessage = (RedisMessage) object;
+        ChatMessage chatMessage = jsonSerializer.deserialize(redisMessage.payload(), ChatMessage.class, ErrorType.CHAT);
+
+        // Controller에서 이미 권한 체크를 했으므로 바로 전송
+        // 프로젝트의 다른 핸들러들과 동일한 패턴으로, 수신한 채널에 그대로 메시지를 보낸다.
+        messagingTemplate.convertAndSend(channel, chatMessage);
     }
 
-    private void handleRoomChat(String channel,  Object object) {
+    private void handleRoomChat(String channel, Object object) {
+        // 룸 채팅 로직 (필요시 구현)
     }
 }

--- a/gotcha-user/src/main/java/gotcha_user/repository/UserRepository.java
+++ b/gotcha-user/src/main/java/gotcha_user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package gotcha_user.repository;
 
 import gotcha_domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +12,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByUuid(String uuid);
+
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.friends LEFT JOIN FETCH u.friendOf WHERE u.uuid = :uuid")
+    Optional<User> findByUuidWithFriends(@Param("uuid") String uuid);
+
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.friends LEFT JOIN FETCH u.friendOf WHERE u.nickname = :nickname")
+    Optional<User> findByNicknameWithFriends(@Param("nickname") String nickname);
 
     Optional<User> findByNickname(String nickname);
 

--- a/gotcha-user/src/main/java/gotcha_user/service/UserService.java
+++ b/gotcha-user/src/main/java/gotcha_user/service/UserService.java
@@ -94,8 +94,20 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
+    public User findUserByNicknameWithFriends(String nickname) {
+        return userRepository.findByNicknameWithFriends(nickname)
+                .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERID));
+    }
+
+    @Transactional(readOnly = true)
     public User findUserByUuid(String uuid) {
         return userRepository.findByUuid(uuid)
+                .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERID));
+    }
+
+    @Transactional(readOnly = true)
+    public User findUserByUuidWithFriends(String uuid) {
+        return userRepository.findByUuidWithFriends(uuid)
                 .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERID));
     }
 

--- a/gotcha-user/src/main/java/gotcha_user/service/UserService.java
+++ b/gotcha-user/src/main/java/gotcha_user/service/UserService.java
@@ -140,6 +140,11 @@ public class UserService {
     public void updateUserChatSetting(Long userId, ChatOption chatOption, PrivateChatOption privateChatOption) {
         User user = findUserByUserId(userId);
         user.updateChatSettings(chatOption, privateChatOption);
+
+        // Redis 캐시 업데이트
+        String settingsCacheKey = "user:" + user.getUuid() + ":settings";
+        redisUtil.hSet(settingsCacheKey, "chatOption", chatOption.name());
+        redisUtil.hSet(settingsCacheKey, "privateChatOption", privateChatOption.name());
     }
 
     public User getUserByUuidAllowingGuest(String uuid) {

--- a/gotcha/src/main/java/Gotcha/domain/friend/listener/FriendSubscribeEventListener.java
+++ b/gotcha/src/main/java/Gotcha/domain/friend/listener/FriendSubscribeEventListener.java
@@ -6,6 +6,7 @@ import gotcha_user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationListener;
+import gotcha_common.util.RedisUtil;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
@@ -22,6 +23,7 @@ public class FriendSubscribeEventListener implements ApplicationListener<Session
     private final UserService userService;
     private final FriendRepository friendRepository;
     private final FriendSocketService friendSocketService;
+    private final RedisUtil redisUtil;
 
     @Override
     public void onApplicationEvent(SessionSubscribeEvent event) {
@@ -50,7 +52,18 @@ public class FriendSubscribeEventListener implements ApplicationListener<Session
                 .distinct()
                 .toList();
 
-        // 4. 각 친구에게 ONLINE 알림
+        // 4. Redis 캐시 워밍 (사용자 설정 및 친구 목록)
+        String settingsCacheKey = "user:" + uuid + ":settings";
+        redisUtil.hSet(settingsCacheKey, "chatOption", user.getChatOption().name());
+        redisUtil.hSet(settingsCacheKey, "privateChatOption", user.getPrivateChatOption().name());
+
+        String friendCacheKey = "user:" + uuid + ":friends";
+        if (!friends.isEmpty()) {
+            String[] friendUuids = friends.stream().map(User::getUuid).toArray(String[]::new);
+            redisUtil.addSetValue(friendCacheKey, friendUuids);
+        }
+
+        // 5. 각 친구에게 ONLINE 알림
         for (User friend : friends) {
             friendSocketService.sendFriendAlert(user.getUuid(), friend.getUuid(), user.getUuid(), FriendEventType.ONLINE);
         }

--- a/gotcha/src/main/java/Gotcha/domain/friend/service/FriendService.java
+++ b/gotcha/src/main/java/Gotcha/domain/friend/service/FriendService.java
@@ -13,6 +13,7 @@ import gotcha_domain.user.User;
 import gotcha_user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import gotcha_common.util.RedisUtil;
 import org.springframework.transaction.annotation.Transactional;
 import socket_server.domain.friend.dto.FriendEventType;
 import socket_server.domain.friend.dto.FriendSummaryRes;
@@ -27,6 +28,9 @@ public class FriendService {
     private final FriendRequestRepository friendRequestRepository;
     private final UserService userService;
     private final FriendSocketService friendSocketService;
+    private final RedisUtil redisUtil;
+
+    private static final String FRIEND_CACHE_PREFIX = "user:";
 
     @Transactional(readOnly = true)
     public List<FriendRes> getFriends(Long userId) {
@@ -111,6 +115,12 @@ public class FriendService {
         Friend friend = new Friend(fromUser, toUser);
         friendRepository.save(friend);
 
+        // Redis 캐시 업데이트
+        String toUserCacheKey = FRIEND_CACHE_PREFIX + toUser.getUuid() + ":friends";
+        String fromUserCacheKey = FRIEND_CACHE_PREFIX + fromUser.getUuid() + ":friends";
+        redisUtil.addSetValue(toUserCacheKey, fromUser.getUuid());
+        redisUtil.addSetValue(fromUserCacheKey, toUser.getUuid());
+
         friendRequestRepository.delete(friendRequest);
 
         FriendSummaryRes friendSummaryRes = FriendSummaryRes.from(friendRequest);
@@ -150,6 +160,12 @@ public class FriendService {
         }
 
         friendRepository.delete(relation);
+
+        // Redis 캐시 업데이트
+        String userCacheKey = FRIEND_CACHE_PREFIX + user.getUuid() + ":friends";
+        String friendCacheKey = FRIEND_CACHE_PREFIX + friend.getUuid() + ":friends";
+        redisUtil.removeSetValue(userCacheKey, friend.getUuid());
+        redisUtil.removeSetValue(friendCacheKey, user.getUuid());
 
         friendSocketService.sendFriendAlert(user.getUuid(), friendUuid, user.getUuid(), FriendEventType.DELETE);
     }


### PR DESCRIPTION
# 채팅 설정에 따른 채팅 필터링 구현

## 📝 개요  

채팅 설정에 따른 채팅 필터링을 구현하였습니다.

---

## ⚙️ 구현 내용  

 ### 1. 채팅 수신 권한 확인 로직 추가
   - `User` 엔티티에 로직 캡슐화: 채팅 수신 가능 여부를 판단하는 canReceiveMessage() 메서드를 User 엔티티에 추가하여, 관련 정책을 객체 스스로가 결정하도록 책임을 위임했습니다.
   - `equals/hashCode` 재정의: 친구 관계(isFriendWith)를 정확하게 비교하기 위해 User 엔티티의 equals와 hashCode 메서드를 id 기준으로 재정의했습니다.
   - `MultipleBagFetchException` 해결: JOIN FETCH 시 여러 List를 동시에 가져올 수 없는 Hibernate 제약사항을 해결하기 위해, User 엔티티 내 OneToMany 관계의 컬렉션 타입을 List에서 Set으로 변경했습니다.


  ### 2. 성능 개선을 위한 캐시 아키텍처 도입 (Redis)
  기존에는 채팅 메시지 처리 시 매번 DB에 사용자 정보와 친구 목록을 조회하여 심각한 성능 저하(N+1 문제)가 우려되었습니다. 이를 해결하기 위해 Redis를 이용한 캐시 기반 아키텍처를 도입했습니다.

   - On-Demand 캐시 워밍: 사용자가 온라인 상태가 될 때(FriendSubscribeEventListener 동작 시), 해당 사용자의 채팅 설정과 친구 목록을 조회하여 Redis에 캐싱하도록 구현했습니다. 이는 서버 시작 시 부하를 줄이고, 실제 활동하는 사용자의 데이터만 효율적으로 관리하는 방식입니다.
   - 캐시 업데이트 로직: 친구 추가/삭제(FriendService) 또는 채팅 설정 변경(UserService) 시, DB와 Redis 캐시가 실시간으로 동기화되도록 관련 로직을 추가했습니다.
   - 채팅 핸들러 리팩토링: ChattingController(귓속말)와 ChattingPubSubHandler(전체 채팅)가 더 이상 DB를 직접 조회하지 않고, Redis 캐시에서 정보를 가져와 필터링을 수행하도록 전면 수정했습니다.

  ### 3. 메시지 처리 흐름 수정
   - `RedisIntegrationConfig` 수정: chatMessageFlow가 필터링 로직을 우회하고 모든 메시지를 브로드캐스팅하던 문제를 발견하여, 모든 채팅 메시지가 ChattingPubSubHandler를 통해 처리되도록 흐름을 수정했습니다.


### 클라이언트 구독 경로 변경 안내
채팅 필터링 기능이 도입됨에 따라, 클라이언트가 구독해야 하는 경로가 다음과 같이 변경되었습니다.

  | 메시지 종류 | 클라이언트 구독 주소 | 설명 |
|--------------|------------------------|----------------------------------|
| **귓속말** | `/sub/chat/private/{본인UUID}` | (기존과 동일) 개인 귓속말 채널 |
| **전체 채팅** | `/user/{본인UUID}/queue/chat` | **(변경)** 필터링을 통과한 메시지만 수신 |

---



</details>
