### PR TITLE
fix: 배포 상황에서 csrf토큰 무한 재발급 오류 수정

### DIFF
--- a/gotcha-common/src/main/java/gotcha_common/config/CsrfConfig.java
+++ b/gotcha-common/src/main/java/gotcha_common/config/CsrfConfig.java
@@ -21,6 +21,14 @@ public class CsrfConfig {
         repository.setCookieHttpOnly(false);
         repository.setSecure(secure);
 
+        repository.setCookieCustomizer(builder -> {
+            if (secure) {
+                builder.sameSite("None");
+            } else {
+                builder.sameSite("Lax");
+            }
+        });
+
         return repository;
     }
 


### PR DESCRIPTION
# 배포 상황에서 csrf토큰 무한 재발급 오류 수정

## 📝 개요  

배포 상황에서 csrf토큰 무한 재발급 오류 수정

---

## ⚙️ 구현 내용  

csrf 토큰의 samesite 설정을 None으로 변경

---
