### PR TITLE
fix: Redis room key namespace 분리로 WRONGTYPE 오류 해결

### DIFF
--- a/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomRepository.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/repository/RoomRepository.java
@@ -28,7 +28,7 @@ public class RoomRepository {
     }
 
     private String getRoomKey(String roomId) {
-        return "room:" + roomId;
+        return "room:data:" + roomId;
     }
 
     public void updateAllFields(String roomId, Map<String, String> updates) {
@@ -44,7 +44,7 @@ public class RoomRepository {
      * @return room 키들(예: "room:1234")을 순회할 수 있는 Cursor 객체
      */
     public Cursor<String> scanRoomKeys() {
-        ScanOptions options = ScanOptions.scanOptions().match("room:*").count(1000).build();
+        ScanOptions options = ScanOptions.scanOptions().match("room:data:*").count(1000).build();
         return redisTemplate.scan(options);
     }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -188,7 +188,7 @@ public class RoomService {
         try (Cursor<String> roomKeys = roomRepository.scanRoomKeys()) {
             while (roomKeys.hasNext()) {
                 String roomKey = roomKeys.next();
-                String roomId = roomKey.replaceFirst("room:", "");
+                String roomId = roomKey.replaceFirst("room:data:", "");
 
                 Map<Object, Object> roomData = roomRepository.getRoomData(roomId);
                 if (roomData == null || roomData.isEmpty()) {


### PR DESCRIPTION
# Redis room key namespace 분리로 WRONGTYPE 오류 해결

## 📝 개요  

현재 /api/v1/room get 매핑 시, 서버 에러 500이 발생됨.


---

## ⚙️ 구현 내용  
Redis 키 네임스페이스 충돌 문제 해결

* 기존 방 메타데이터 키: room:{roomId} -> hash 자료구조
* 방 ID 풀 키: room:ids:available -> set 자료구조

두 키가 모두 room:* 패턴에 포함되어 SCAN 후 HGETALL 수행 시 Set 타입에서 WRONGTYPE 발생
**set 타입은  HGETALL 이 아닌  SMEMBERS 명령어로 조회해야 하기에, 레디스 내에서 명령어 불일치 에러가 발생되었음!**

<해당 조회 코드>
```java
    public Cursor<String> scanRoomKeys() {
        ScanOptions options = ScanOptions.scanOptions().match("room:*").count(1000).build();
        return redisTemplate.scan(options);
    }

```

방 메타데이터 키를 아래와 같이 변경

* room:data:{roomId}
* 기존 room:ids:available는 유지
---

## 🧪 테스트 결과  
<img width="1066" height="640" alt="image" src="https://github.com/user-attachments/assets/bf31b897-0868-4787-b448-e6ad4f5a4082" />


---
