### PR TITLE
fix : 로그인 시 확인하던 인가(정지계정 유무) 로직 핸드쉐이크 시점으로 이동

### DIFF
--- a/gotcha-socket/src/main/java/socket_server/common/auth/JwtChannelInterceptor.java
+++ b/gotcha-socket/src/main/java/socket_server/common/auth/JwtChannelInterceptor.java
@@ -48,6 +48,9 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
             } catch (AuthenticationServiceException e) {
                 throw new MessagingException(toErrorPayload(JwtExceptionCode.ACCESS_TOKEN_NOT_FOUND));
             } catch (Throwable e) {
+                System.err.println("=== [DEBUG][JwtChannelInterceptor] 예외 발생 ===");
+                e.printStackTrace();
+
                 throw new MessagingException(toErrorPayload(GlobalExceptionCode.INTERNAL_SERVER_ERROR));
             }
         }
@@ -62,7 +65,6 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
                 code.getMessage()
         );
     }
-
 
 
 }

--- a/gotcha-socket/src/main/java/socket_server/common/auth/UserStatusInterceptor.java
+++ b/gotcha-socket/src/main/java/socket_server/common/auth/UserStatusInterceptor.java
@@ -1,0 +1,58 @@
+package socket_server.common.auth;
+
+import gotcha_common.exception.exceptionCode.ExceptionCode;
+import gotcha_common.exception.exceptionCode.GlobalExceptionCode;
+import gotcha_domain.auth.SecurityUserDetails;
+import gotcha_domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import socket_server.common.exception.socket.SocketUserStatusExceptionCode;
+
+@Component
+@RequiredArgsConstructor
+public class UserStatusInterceptor implements ChannelInterceptor {
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        try {
+            if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+                Authentication auth = (Authentication) accessor.getUser();
+                SecurityUserDetails details = (SecurityUserDetails) auth.getPrincipal();
+                User user = details.getUser();
+
+                SocketUserStatusExceptionCode code =
+                        SocketUserStatusExceptionCode.fromStatus(user.getUserStatus());
+
+                if (code != null) {
+                    throw new MessagingException(toErrorPayload(code));
+                }
+
+            }
+
+            return message;
+        } catch (Throwable e) {
+            if (e instanceof MessagingException) {
+                throw (MessagingException) e;
+            }
+            System.err.println("=== [DEBUG][UserStatusInterceptor] 예외 발생 ===");
+            e.printStackTrace();
+
+            throw new MessagingException(toErrorPayload(GlobalExceptionCode.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private String toErrorPayload(ExceptionCode code) {
+        return String.format("{\"errorCode\":\"%s\", \"status\":%d, \"message\":\"%s\"}", code.getCode(),
+                code.getStatus().value(), code.getMessage());
+    }
+}

--- a/gotcha-socket/src/main/java/socket_server/common/config/WebSocketConfig.java
+++ b/gotcha-socket/src/main/java/socket_server/common/config/WebSocketConfig.java
@@ -8,6 +8,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import socket_server.common.auth.JwtChannelInterceptor;
+import socket_server.common.auth.UserStatusInterceptor;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -15,10 +16,14 @@ import socket_server.common.auth.JwtChannelInterceptor;
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private static final String ENDPOINT = "/ws-connect";
     private final JwtChannelInterceptor jwtChannelInterceptor;
+    private final UserStatusInterceptor userStatusInterceptor;
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(jwtChannelInterceptor);
+        registration.interceptors(
+                jwtChannelInterceptor,       // 1. 인증(jwt)
+                userStatusInterceptor        // 2. 인가(정지 계정)
+        );
     }
 
     //레디스 메시지 브로커 사용

--- a/gotcha-socket/src/main/java/socket_server/common/exception/socket/SocketUserStatusExceptionCode.java
+++ b/gotcha-socket/src/main/java/socket_server/common/exception/socket/SocketUserStatusExceptionCode.java
@@ -1,0 +1,39 @@
+package socket_server.common.exception.socket;
+
+import gotcha_common.exception.exceptionCode.ExceptionCode;
+import gotcha_domain.user.UserStatus;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum SocketUserStatusExceptionCode implements ExceptionCode {
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, "SOCKET-403-001", "계정이 일시 정지되었습니다."),
+    USER_BANNED(HttpStatus.FORBIDDEN, "SOCKET-403-002", "계정이 영구 정지되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public static SocketUserStatusExceptionCode fromStatus(UserStatus status) {
+        return switch (status) {
+            case SUSPENDED -> USER_SUSPENDED;
+            case BANNED    -> USER_BANNED;
+            default        -> null;  // 정상 계정
+        };
+    }
+}

--- a/gotcha/src/main/java/Gotcha/domain/auth/service/SignInUseCase.java
+++ b/gotcha/src/main/java/Gotcha/domain/auth/service/SignInUseCase.java
@@ -27,16 +27,13 @@ public class SignInUseCase {
         // 2. 정지기간 만료되었는지 확인
         sanctionService.validateSuspendedEndDate(user);
 
-        // 3. 제재/차단 상태 확인
-        sanctionService.validateLoginAccess(user);
-
-        // 4. 경고 확인
+        // 3. 경고 확인
         Optional<SanctionRes> warningOpt = sanctionService.findAndMarkUnreadWarning(user);
 
-        // 5. 토큰 생성
+        // 4. 토큰 생성
         TokenDto tokenDto = jwtHelper.createToken(user, signInReq.autoSignIn());
 
-        // 6. 경고 메시지가 있으면 토큰에 추가하여 반환
+        // 5. 경고 메시지가 있으면 토큰에 추가하여 반환
         return warningOpt
                 .map(warning -> TokenDto.of(tokenDto.accessToken(), tokenDto.refreshToken(), tokenDto.accessTokenExpiredAt(), tokenDto.autoSignIn(), warning))
                 .orElse(tokenDto);

--- a/gotcha/src/main/java/Gotcha/domain/sanction/service/SanctionService.java
+++ b/gotcha/src/main/java/Gotcha/domain/sanction/service/SanctionService.java
@@ -1,7 +1,5 @@
 package Gotcha.domain.sanction.service;
 
-import Gotcha.domain.auth.exception.AuthExceptionCode;
-import Gotcha.domain.auth.exception.UserAccountStatusException;
 import Gotcha.domain.report.service.UserReportService;
 import Gotcha.domain.sanction.dto.SanctionReq;
 import Gotcha.domain.sanction.dto.SanctionRes;
@@ -14,13 +12,10 @@ import gotcha_domain.sanction.UserSanction;
 import gotcha_domain.user.User;
 import gotcha_domain.user.UserStatus;
 import gotcha_user.service.UserService;
-import jakarta.persistence.TableGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -68,25 +63,6 @@ public class SanctionService {
     }
 
     @Transactional
-    public void validateLoginAccess(User user) {
-        if (user.getUserStatus() == UserStatus.SUSPENDED || user.getUserStatus() == UserStatus.BANNED) {
-            AuthExceptionCode code = user.getUserStatus() == UserStatus.SUSPENDED ?
-                    AuthExceptionCode.ACCOUNT_SUSPENDED : AuthExceptionCode.ACCOUNT_BANNED;
-
-            UserSanction sanction = findLatestUnread(user)
-                    .orElseThrow(()->new CustomException(AuthExceptionCode.SANCTION_NOT_FOUND));
-            sanction.markAsRead();
-
-            Map<String, Object> details = new HashMap<>();
-            details.put("reason", sanction.getReason());
-            if (sanction.getExpireDuration() != null) {
-                details.put("expireDuration", sanction.getExpireDuration());
-            }
-            throw new UserAccountStatusException(code, details);
-        }
-    }
-
-    @Transactional
     public void validateSuspendedEndDate(User user) {
         if(user.getUserStatus()==UserStatus.SUSPENDED) {
             user.checkSuspensionAndUnsuspend();
@@ -100,10 +76,6 @@ public class SanctionService {
                     warning.markAsRead();
                     return SanctionRes.fromEntity(warning);
                 });
-    }
-
-    public Optional<UserSanction> findLatestUnread(User user) {
-        return sanctionRepository.findTopByUserAndIsReadIsFalseOrderByCreatedAtDesc(user);
     }
 
     public Optional<UserSanction> findLatestUnread(User user, SanctionType type) {


### PR DESCRIPTION
# fix : 로그인 시 확인하던 인가(정지계정 유무) 로직 핸드쉐이크 시점으로 이동

## 📝 개요  

일시정지/영구정지를 받은 계정은 로그인은 가능해야 하며, 게임 시작이 되지 않아야 한다. 는 규칙에 따라 로직을 변경했습니다.
---

## ⚙️ 구현 내용  

### 1. 인가(정지계정 유무) 확인할 채널 인터셉터 생성
이전 코드에서는 핸드쉐이킹 시 jwt 토큰만 확인했지만, 인가용 채널을 하나 더 추가했습니다.

또한 기존 코드에서 해당 에러메시지는 AuthExceptionCode 에서 관리했지만, 의존성 문제로 인하여  SocketUserStatusExceptionCode  라는 enum 클래스를 새로 추가하였습니다.

<img width="811" height="114" alt="image" src="https://github.com/user-attachments/assets/10498472-31a3-4fb8-aa23-7e3070f398e4" />


### 2. SignInUseCase 로직 변경

기존 로직은 다음과 같이 진행됩니다.
<img width="1103" height="503" alt="image" src="https://github.com/user-attachments/assets/b038bcb6-0b24-4355-975f-2448ed201165" />

여기서 validateLogin 함수와 findAndMarkUnreadWarning 함수는 다음과 같은 역할을 합니다.

**validateLogin( )**
- 유저가 일시정지거나, 영구정지일 경우 유저의 가장 최신 제재(WARNING, 일시 정지, 영구 정지)를 찾아 읽음 표시 합니다.
- 다른 로직 생략

**findAndMarkUnreadWarning( )**
- 해당 유저의 WARNING 제재 중, 읽지 않은 가장 최근 제재 1개를 가져옵니다.
- 해당 내역을 프론트에게 전달합니다.

사실상 유저가 일시 정지거나 영구 정지인 경우에서 유저의 최신 제재가 WARNING의 경우,  validateLogin 함수에서 읽음처리 되기에 findAndMarkUnreadWarning 함수가 실행되지 않습니다.

즉 프론트는 올바른 값을 받지 않습니다.

이러한 문제를 해결하기 위해,
그리고 로그인 가능 여부 판단 기능을 인가 채널 인터셉터로 이동시킨 구조 변경과 맞추기 위해,

**validateLogin() 메서드는 더 이상 필요하지 않아 삭제하였습니다.**

---

## 📎 기타

---

## 🧪 테스트 결과  

### 1. 소켓 접속 시 인가 확인 에러 반환 확인
<img width="669" height="112" alt="image" src="https://github.com/user-attachments/assets/2ed1fc60-f2e8-4bde-ba74-80dbf7b73f9d" />


---
