### PR TITLE
fix: 대기방 준비 상태 관련 수정

### DIFF
--- a/gotcha-socket/src/main/java/socket_server/domain/game/service/GameStartService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/service/GameStartService.java
@@ -2,6 +2,7 @@ package socket_server.domain.game.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import socket_server.common.exception.ErrorType;
@@ -34,7 +35,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class GameStartService {
-
+    @Qualifier("taskScheduler")
     private final TaskScheduler taskScheduler;
     private final RoomUserService roomUserService;
     private final GamePlayerRepository gamePlayerRepository;
@@ -91,6 +92,16 @@ public class GameStartService {
 
         // 8. 5초 후 게임 시작(EntryPoint)
         taskScheduler.schedule(() -> roundStartService.startNextRound(roomId), Instant.now().plusSeconds(5));
+
+        List<RoomUserInfo> users = new ArrayList<>(roomUserRepository.findUsersByRoomId(roomId, errorType));
+        String ownerUuid = roomMetadata.getOwnerUuid();
+
+        for (RoomUserInfo user : users) {
+            if (!user.getUserUuid().equals(ownerUuid)) {
+                user.setReady(false);
+                roomUserRepository.saveUserToRoom(user, roomId, errorType);
+            }
+        }
     }
 
     private void saveGame(Game game) {

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomService.java
@@ -171,7 +171,8 @@ public class RoomService {
         RoomSummaryRes summary = RoomSummaryRes.of(metadata, currentUser);
         lobbyBroadCaster.broadcastToRoomList("SYSTEM", RoomEventType.UPDATE, summary);
 
-        List<RoomUserInfo> userList = roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR);
+        List<RoomUserInfo> userList = new ArrayList<>(roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR));
+        sortUserListWithOwnerFirst(userList, metadata.getOwnerUuid());
         RoomDetailRes roomDetailRes = new RoomDetailRes(RoomInfoRes.from(metadata), userList);
         roomBroadcaster.broadcastToRoom(roomId, "SYSTEM", RoomEventType.UPDATE, roomDetailRes);
 
@@ -224,8 +225,21 @@ public class RoomService {
         }
 
         RoomMetadata metadata = RoomMetadata.fromRedisMap(roomId, roomData);
-        List<RoomUserInfo> userList = roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR);
+        List<RoomUserInfo> userList = new ArrayList<>(roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR));
+        sortUserListWithOwnerFirst(userList, metadata.getOwnerUuid());
 
         return new RoomDetailRes(RoomInfoRes.from(metadata), userList);
+    }
+
+    private void sortUserListWithOwnerFirst(List<RoomUserInfo> userList, String ownerUuid) {
+        userList.sort((u1, u2) -> {
+            if (u1.getUserUuid().equals(ownerUuid)) {
+                return -1;
+            }
+            if (u2.getUserUuid().equals(ownerUuid)) {
+                return 1;
+            }
+            return 0;
+        });
     }
 }

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -104,6 +104,10 @@ public class RoomUserService {
             throw new SocketCustomException(ROOM_ERROR, RoomExceptionCode.NOT_ROOM_OWNER);
         }
 
+        RoomUserInfo oldOwner = roomUserRepository.findUserInfoInRoom(roomId, oldOwnerId, ROOM_ERROR);
+        oldOwner.setReady(false);
+        roomUserRepository.saveUserToRoom(oldOwner, roomId, ROOM_ERROR);
+
         RoomUserInfo newOwner = roomUserRepository.findUserInfoInRoom(roomId, newOwnerId, ROOM_ERROR);
 
         changeRoomOwner(roomId, newOwner);
@@ -147,6 +151,9 @@ public class RoomUserService {
     }
 
     public void changeRoomOwner(String roomId, RoomUserInfo newOwner) {
+        newOwner.setReady(true);
+        roomUserRepository.saveUserToRoom(newOwner, roomId, ROOM_ERROR);
+
         roomRepository.updateAllFields(roomId, Map.of(
                 RoomField.OWNER_UUID.getRedisField(), newOwner.getUserUuid(),
                 RoomField.OWNER.getRedisField(), newOwner.getNickname()

--- a/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/room/service/RoomUserService.java
@@ -19,6 +19,7 @@ import socket_server.domain.room.model.RoomUserInfo;
 import socket_server.domain.room.repository.RoomRepository;
 import socket_server.domain.room.repository.RoomUserRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -161,7 +162,8 @@ public class RoomUserService {
 
         RoomMetadata updatedMetadata = RoomMetadata.fromRedisMap(roomId, roomRepository.getRoomData(roomId));
         RoomInfoRes roomInfoRes = RoomInfoRes.from(updatedMetadata);
-        List<RoomUserInfo> userList = roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR);
+        List<RoomUserInfo> userList = new ArrayList<>(roomUserRepository.findUsersByRoomId(roomId, ROOM_ERROR));
+        sortUserListWithOwnerFirst(userList, updatedMetadata.getOwnerUuid());
         RoomDetailRes detailRes = new RoomDetailRes(roomInfoRes, userList);
         roomBroadcaster.broadcastToRoom(roomId, newOwner.getUserUuid(), RoomEventType.UPDATE, detailRes);
 
@@ -169,6 +171,18 @@ public class RoomUserService {
         RoomSummaryRes roomSummaryRes = RoomSummaryRes.of(updatedMetadata, currentUserCount);
         lobbyBroadCaster.broadcastToRoomList("SYSTEM", RoomEventType.UPDATE, roomSummaryRes);
         log.info("방장 권한이 {}에게 위임되었습니다. (roomId: {})", newOwner.getUserUuid(), roomId);
+    }
+
+    private void sortUserListWithOwnerFirst(List<RoomUserInfo> userList, String ownerUuid) {
+        userList.sort((u1, u2) -> {
+            if (u1.getUserUuid().equals(ownerUuid)) {
+                return -1;
+            }
+            if (u2.getUserUuid().equals(ownerUuid)) {
+                return 1;
+            }
+            return 0;
+        });
     }
 
     public RoomMetadata validateRoomOwnerAndGetRoomMetadata(String roomId, String userUuid) {


### PR DESCRIPTION
# 대기방 준비 상태 관련 수정

## 📝 개요  

대기방 준비 상태 관련 수정

---

## ⚙️ 구현 내용  

슬랙의 이슈와 같이 기존에 방장 권한을 위임하면 준비상태가 꼬이게되는 문제가 있어,
기존의 방장의 준비상태를 false로, 새로운 방장의 준비상태를 true로 변경해주었습니다.

대기방 userList를 보내주는 과정에서 방장을 기준으로 정렬하여 보내도록 했습니다.

게임이 종료하고 방장을 제외한 모든 사용자의 준비상태를 false로 변경합니다.

---
