### PR TITLE
fix: 게임1 로직 수정

### DIFF
--- a/gotcha-socket/src/main/java/socket_server/domain/game/repository/GameRepository.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/repository/GameRepository.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 public class GameRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
+    //todo: Lock 관련 코드 전면 수정
     private final RedissonClient redissonClient;
 
     public GameRepository(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate, RedissonClient redissonClient) {
@@ -39,11 +40,11 @@ public class GameRepository {
      */
     public void saveGameMeta(GameMeta gameMeta) {
         String redisKey = getGameKey(gameMeta.getRoomId());   // Redis 해시 키
-        String lockKey = "lock:" + redisKey; // 락 키
-
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey; // 락 키
+//
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 Map<String, Object> gameData = Map.of(
                         "gameType", gameMeta.getGameType().name(),
                         "difficulty", gameMeta.getDifficulty().name(),
@@ -55,17 +56,17 @@ public class GameRepository {
                         "playerWon", String.valueOf(gameMeta.getPlayerWon())
                 );
                 redisTemplate.opsForHash().putAll(getGameKey(gameMeta.getRoomId()), gameData);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     /**
@@ -73,22 +74,22 @@ public class GameRepository {
      */
     public Map<Object, Object> findGameMeta(String roomId) {
         String redisKey = getGameKey(roomId);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 return redisTemplate.opsForHash().entries(redisKey);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     public void deleteGameMeta(String roomId){

--- a/gotcha-socket/src/main/java/socket_server/domain/game/repository/RoundRepository.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/repository/RoundRepository.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 @Repository
 public class RoundRepository {
     private final RedisTemplate<String, String> redisTemplate;
+    //todo: Lock 관련 코드 전면 수정
     private final RedissonClient redissonClient;
 
     public RoundRepository(@Qualifier("socketStringRedisTemplate") RedisTemplate<String, String> redisTemplate, RedissonClient redissonClient) {
@@ -36,23 +37,23 @@ public class RoundRepository {
      */
     public void saveRoundMetasString(String roomId, String roundsJson) {
         String redisKey = getGameRoundsKey(roomId);
-        String lockKey = "lock:" + redisKey;
-
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 redisTemplate.opsForValue().set(redisKey, roundsJson);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     /**
@@ -60,22 +61,22 @@ public class RoundRepository {
      */
     public String findRoundMetasString(String roomId) {
         String key = getGameRoundsKey(roomId);
-        String lockKey = "lock:" + key;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + key;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 return redisTemplate.opsForValue().get(key);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
 
@@ -96,22 +97,22 @@ public class RoundRepository {
      */
     public void saveWordMetasString(String roomId, int roundIndex, String wordsJson) {
         String redisKey = getRoundWordsKey(roomId, roundIndex);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 redisTemplate.opsForValue().set(redisKey, wordsJson);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     /**
@@ -119,22 +120,22 @@ public class RoundRepository {
      */
     public String findWordMetasString(String roomId, int roundIndex) {
         String redisKey = getRoundWordsKey(roomId, roundIndex);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 return redisTemplate.opsForValue().get(redisKey);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     public void deleteWordMetas(String roomId, int roundIndex) {
@@ -152,22 +153,22 @@ public class RoundRepository {
      */
     public void saveAIPredictionsString(String roomId, int roundIndex, int wordIndex, String predictionsJson){
         String redisKey = getAIPredicionsKey(roomId, roundIndex, wordIndex);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 redisTemplate.opsForValue().set(redisKey, predictionsJson);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     /**
@@ -175,22 +176,22 @@ public class RoundRepository {
      */
     public String findAIPredictionsString(String roomId, int roundIndex, int wordIndex) {
         String redisKey = getAIPredicionsKey(roomId, roundIndex, wordIndex);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 return redisTemplate.opsForValue().get(redisKey);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     public void deleteAIPredictions(String roomId, int roundIndex, int wordIndex) {
@@ -209,22 +210,22 @@ public class RoundRepository {
      */
     public void saveAIGuessesString(String roomId, int roundIndex, int wordIndex, String guessesJson){
         String redisKey = getAIGuessKey(roomId, roundIndex, wordIndex);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 redisTemplate.opsForValue().set(redisKey, guessesJson);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     /**
@@ -232,22 +233,22 @@ public class RoundRepository {
      */
     public String findAIGuessesString(String roomId, int roundIndex, int wordIndex) {
         String redisKey = getAIGuessKey(roomId, roundIndex, wordIndex);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 return redisTemplate.opsForValue().get(redisKey);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     public void deleteAIGuesses(String roomId, int roundIndex, int wordIndex) {
@@ -267,22 +268,22 @@ public class RoundRepository {
      */
     public String findPlayerGuessesString(String roomId, int roundIndex, int wordIndex) {
         String redisKey = getPlayerGuessKey(roomId, roundIndex, wordIndex);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 return redisTemplate.opsForValue().get(redisKey);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     /**
@@ -290,22 +291,22 @@ public class RoundRepository {
      */
     public void savePlayerGuesses(String roomId, int roundIndex, int wordIndex, String guessesJson){
         String redisKey = getPlayerGuessKey(roomId, roundIndex, wordIndex);
-        String lockKey = "lock:" + redisKey;
-        RLock lock = redissonClient.getLock(lockKey);
-        try {
-            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
+//        String lockKey = "lock:" + redisKey;
+//        RLock lock = redissonClient.getLock(lockKey);
+//        try {
+//            if (lock.tryLock(1, 5, TimeUnit.SECONDS)) { // 1초 기다리고, 5초 동안 유지
                 redisTemplate.opsForValue().set(redisKey, guessesJson);
-            } else {
-                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); //
-            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+//            } else {
+//                throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_ACQUISITION_FAILED);
+//            }
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt(); //
+//            throw new SocketCustomException(ErrorType.GAME, GameExceptionCode.LOCK_INTERRUPTED);
+//        } finally {
+//            if (lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
     }
 
     public void deletePlayerGuesses(String roomId, int roundIndex, int wordIndex) {

--- a/gotcha-socket/src/main/java/socket_server/domain/game/service/GuessFlowService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/service/GuessFlowService.java
@@ -67,7 +67,7 @@ public class GuessFlowService {
 //        log.info("[GUESS_START] broadcasted");
         gameMeta.setGameStatus(GameStatus.GUESSING_STARTED);
         gameRepository.saveGameMeta(gameMeta);
-        taskScheduler.schedule(() ->processNextGuessRequest(roomId), Instant.now().plusSeconds(1));
+        taskScheduler.schedule(() ->processNextGuessRequest(roomId), Instant.now().plusSeconds(2));
     }
 
 
@@ -94,6 +94,7 @@ public class GuessFlowService {
 
         boolean isAITurn = determineNextGuesser(currentWord);
         if(isAITurn){ // next guess
+
             Guess newGuess = guessRequestService.requestGuessAI(roomId, gameMeta, currentWord);
             taskScheduler.schedule(() ->
                 handleAIGuessSubmit(roomId, currentRound, currentWord, newGuess)

--- a/gotcha-socket/src/main/java/socket_server/domain/game/service/GuessFlowService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/service/GuessFlowService.java
@@ -391,7 +391,7 @@ public class GuessFlowService {
         if(isWordGuessCompleted(currentWord)){
             taskScheduler.schedule(() ->handleBattleEnd(roomId, currentRound, currentWord), Instant.now().plusSeconds(1));
         } else {
-            processNextGuessRequest(roomId);
+            taskScheduler.schedule(() -> processNextGuessRequest(roomId), Instant.now().plusSeconds(2));
         }
     }
 

--- a/gotcha-socket/src/main/java/socket_server/domain/game/service/GuessRequestService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/service/GuessRequestService.java
@@ -77,7 +77,7 @@ public class GuessRequestService {
 
         // 3. BUILD NEW GUESS DATA
         Guess guess = Guess.builder().guesserUuid(gusser.getPlayerUuid()).attempts(guesses.size()+1).build();
-        guess.setGuessEndTime(LocalDateTime.now().plusSeconds(32));
+        guess.setGuessEndTime(LocalDateTime.now().plusSeconds(62));
 
         // 4. BroadCast
         gameBroadCaster.broadcastGameEvent("SYSTEM", roomId, GameEventType.GUESS_REQUEST, guess, aiSays);

--- a/gotcha-socket/src/main/java/socket_server/domain/game/service/RoundStartService.java
+++ b/gotcha-socket/src/main/java/socket_server/domain/game/service/RoundStartService.java
@@ -63,7 +63,7 @@ public class RoundStartService {
                 new AIRoundStartReq(currentRound, gameMeta.getTotalRounds())
         );
 
-        currentRoundMeta.setDrawingEndTime(LocalDateTime.now().plusSeconds(30));
+        currentRoundMeta.setDrawingEndTime(LocalDateTime.now().plusSeconds(60));
         gameBroadCaster.broadcastGameEvent("SYSTEM", roomId, GameEventType.ROUND_START, currentRoundMeta, aiSays);
     }
 


### PR DESCRIPTION
# fix: 게임1 로직 수정

## 📝 개요  

1. 게임1 로직 중 대기시간 관련
  - 사용자가 그림 추측을 시작하는 시간 타이밍이 맞지 않던 문제
  - 시연 시 편의를 위해 추측 제출 기한을 1분으로 수정
  - 시연 시 편의를 위해 그림 제출 기한을 1분으로 수정
2. 게임1 데이터 처리 관련
  - 기존의 게임1 데이터 접근 시 동시성 문제 발생하는 것 확인, 이에 따른 Lock 관련 코드 있음
  - 기존에 작성된 Lock 관련 코드는 Repository 계층에 존재 -> 의미 없는 Lock 연산들
  - 시연 시 성능 향상을 위해 Lock 관련 코드 전부 주석처리, 추후 Service 계층으로 옮겨 완전한 Lock 로직 완성 예정
  - (기존에 작성되어 있던 Lock 관련 코드는 전부 의미없는 연산들이였음... 지금까지 테스트한 모든 환경이 이 문제가 해결되지 않은 상태였음)
  - (잘못된 게임 데이터 접근 시 예외 처리를 위한 코드는 많이 있음 이 문제가 지금 시연에서 터질 확률은 극히 낮음)

---

## ⚙️ 구현 내용  

<!-- 구현한 내용 -->

---

## 📎 기타

<!-- 참고 사항, 이슈, 고려했던 사항 등 -->

---

## 🧪 테스트 결과  

<!-- 테스트 내용 (선택) -->

---
